### PR TITLE
Allow disabling of asm, core_intrinsics and const_fn to build on stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: rust
 
 rust:
+    - stable
+    - beta
     - nightly
 
 sudo: false
@@ -10,11 +12,26 @@ notifications:
         on_success: never
         on_failure: always
 
+before_script:
+  - |
+      pip install 'travis-cargo<0.2' --user &&
+      export PATH=$HOME/.local/bin:$PATH
+
 script:
-    - cargo build
-    - cargo test
-    - cargo doc --no-deps
+    # Nightly tests with default features
+    - travis-cargo --only nightly build
+    - travis-cargo --only nightly test
+    - travis-cargo --only nightly doc -- --no-deps
+    # Ensure things work with features disabled
+    - travis-cargo build -- --no-default-features
+    - travis-cargo test -- --no-default-features
     - rustdoc --test README.md -L target/debug
 
 after_success:
     - curl https://mvdnes.github.io/rust-docs/travis-doc-upload.sh | bash
+
+env:
+  global:
+    # override the default `--features unstable` used by travis-cargo
+    # since unstable is activated by default
+    - TRAVIS_CARGO_NIGHTLY_FEATURE=""

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,5 +18,7 @@ and static initializers are available.
 [features]
 asm = []
 core_intrinsics = []
-unstable = ["asm", "core_intrinsics"]
+const_fn = []
+once = ["const_fn"]
+unstable = ["asm", "core_intrinsics", "const_fn", "once"]
 default = ["unstable"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,6 @@ and static initializers are available.
 
 [features]
 asm = []
-unstable = ["asm"]
+core_intrinsics = []
+unstable = ["asm", "core_intrinsics"]
 default = ["unstable"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,8 @@ They may contain data,
 They are usable without `std`
 and static initializers are available.
 """
+
+[features]
+asm = []
+unstable = ["asm"]
+default = ["unstable"]

--- a/README.md
+++ b/README.md
@@ -12,13 +12,18 @@ This Rust library implements a simple
 Usage
 -----
 
-The current version only works on nightly. This is because it is inteded to use with `no_std` crates, which already need a nightly compiler.
+By default this crate only works on nightly but you can disable the default features
+if you want to run on stable. Nightly is more efficient than stable currently.
+
+Also, `Once` is only available on nightly as it is only useful when `const_fn` is available.
 
 Include the following code in your Cargo.toml
 
 ```toml
-[dependencies]
-spin = "0.3"
+[dependencies.spin]
+version = "0.3"
+# If you want to run on stable you will need to add the following:
+# default-features = false
 ```
 
 Example

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,8 @@
 
 #![cfg_attr(feature = "asm", feature(asm))]
 #![cfg_attr(feature = "core_intrinsics", feature(core_intrinsics))]
-#![feature(const_fn)]
+#![cfg_attr(feature = "const_fn", feature(const_fn))]
+
 #![no_std]
 
 #[cfg(test)]
@@ -14,10 +15,14 @@ extern crate std;
 
 pub use mutex::*;
 pub use rw_lock::*;
+
+#[cfg(feature = "once")]
 pub use once::*;
 
 mod mutex;
 mod rw_lock;
+
+#[cfg(feature = "once")]
 mod once;
 
 mod util;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,8 @@
 
 //! Synchronization primitives based on spinning
 
-#![feature(const_fn, asm, core_intrinsics)]
+#![cfg_attr(feature = "asm", feature(asm))]
+#![feature(const_fn, core_intrinsics)]
 #![no_std]
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,8 @@
 //! Synchronization primitives based on spinning
 
 #![cfg_attr(feature = "asm", feature(asm))]
-#![feature(const_fn, core_intrinsics)]
+#![cfg_attr(feature = "core_intrinsics", feature(core_intrinsics))]
+#![feature(const_fn)]
 #![no_std]
 
 #[cfg(test)]

--- a/src/mutex.rs
+++ b/src/mutex.rs
@@ -114,7 +114,32 @@ impl<T> Mutex<T>
     ///     drop(lock);
     /// }
     /// ```
+    #[cfg(feature = "const_fn")]
     pub const fn new(user_data: T) -> Mutex<T>
+    {
+        Mutex
+        {
+            lock: ATOMIC_BOOL_INIT,
+            data: UnsafeCell::new(user_data),
+        }
+    }
+
+    /// Creates a new spinlock wrapping the supplied data.
+    ///
+    /// If you want to use it statically, you can use the `const_fn` feature.
+    ///
+    /// ```
+    /// use spin;
+    ///
+    /// fn demo() {
+    ///     let mutex = spin::Mutex::new(());
+    ///     let lock = mutex.lock();
+    ///     // do something with lock
+    ///     drop(lock);
+    /// }
+    /// ```
+    #[cfg(not(feature = "const_fn"))]
+    pub fn new(user_data: T) -> Mutex<T>
     {
         Mutex
         {
@@ -247,6 +272,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "const_fn")]
     fn lots_and_lots() {
         static M: Mutex<()>  = Mutex::new(());
         static mut CNT: u32 = 0;

--- a/src/rw_lock.rs
+++ b/src/rw_lock.rs
@@ -94,7 +94,33 @@ impl<T> RwLock<T>
     /// }
     /// ```
     #[inline]
+    #[cfg(feature = "const_fn")]
     pub const fn new(user_data: T) -> RwLock<T>
+    {
+        RwLock
+        {
+            lock: ATOMIC_USIZE_INIT,
+            data: UnsafeCell::new(user_data),
+        }
+    }
+
+    /// Creates a new spinlock wrapping the supplied data.
+    ///
+    /// If you want to use it statically, you can use the `const_fn` feature.
+    ///
+    /// ```
+    /// use spin;
+    ///
+    /// fn demo() {
+    ///     let rw_lock = spin::RwLock::new(());
+    ///     let lock = rw_lock.read();
+    ///     // do something with lock
+    ///     drop(lock);
+    /// }
+    /// ```
+    #[inline]
+    #[cfg(not(feature = "const_fn"))]
+    pub fn new(user_data: T) -> RwLock<T>
     {
         RwLock
         {

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,6 +1,6 @@
 /// Called while spinning (name borrowed from Linux). Can be implemented to call
 /// a platform-specific method of lightening CPU load in spinlocks.
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]
 #[inline(always)]
 pub fn cpu_relax() {
     // This instruction is meant for usage in spinlock loops
@@ -8,7 +8,7 @@ pub fn cpu_relax() {
     unsafe { asm!("pause" :::: "volatile"); }
 }
 
-#[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+#[cfg(any(not(feature = "asm"), not(any(target_arch = "x86", target_arch = "x86_64"))))]
 #[inline(always)]
 pub fn cpu_relax() {
 }


### PR DESCRIPTION
This also disabled `Once` when `const_fn` is not active as it doesn't seem to be useful without it (and there's no tests exercising it without static usage).

This shouldn't break anything as the default features are opt-in and should give the same behaviour as before.