### PR TITLE
Improve Mutex performance

### DIFF
--- a/src/mutex.rs
+++ b/src/mutex.rs
@@ -163,7 +163,11 @@ impl<T: ?Sized> Mutex<T>
     {
         while self.lock.compare_and_swap(false, true, Ordering::Acquire) != false
         {
-            cpu_relax();
+            // Wait until the lock looks unlocked before retrying
+            while self.lock.load(Ordering::Relaxed)
+            {
+                cpu_relax();
+            }
         }
     }
 


### PR DESCRIPTION
Replaces the CAS-loop locking the mutex with a loop trying one CAS and
then falling back on a read-only loop that spins until the lock
"looks unlocked" before trying CAS again.

This improves performance by reducing contention for the lock
cache line ("ping-ponging"). Unlike CAS, an atomic load does not
requires exclusive ownership of the cache line.

---

I did some benchmarking, using different number of threads trying to
increment an `u32` guarded by a `Mutex`. The timings are the time taken
for all threads to finish 10000 increments each. This was tested a quad-core
Intel i5 2500K.

Before:
```
test mutex_01 ... bench:     114,381 ns/iter (+/- 13,282) = 87 MB/s
test mutex_02 ... bench:     961,716 ns/iter (+/- 203,341) = 20 MB/s
test mutex_04 ... bench:   3,400,672 ns/iter (+/- 695,725) = 11 MB/s
test mutex_08 ... bench:   9,463,981 ns/iter (+/- 4,597,341) = 8 MB/s
test mutex_16 ... bench:  27,007,718 ns/iter (+/- 28,721,488) = 5 MB/s
```

After:
```
test mutex_01 ... bench:     112,775 ns/iter (+/- 11,286) = 88 MB/s
test mutex_02 ... bench:     592,634 ns/iter (+/- 161,804) = 33 MB/s
test mutex_04 ... bench:   1,734,625 ns/iter (+/- 498,607) = 23 MB/s
test mutex_08 ... bench:   3,315,700 ns/iter (+/- 2,082,837) = 24 MB/s
test mutex_16 ... bench:  10,433,348 ns/iter (+/- 7,608,357) = 15 MB/s
```