### PR TITLE
Separate the spinlock implementation.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "spin"
-version = "0.4.5"
+version = "0.5.0"
 authors = [ "Mathijs van de Nes <git@mathijs.vd-nes.nl>",
             "John Ericson <John_Ericson@Yahoo.com>" ]
 license = "MIT"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,8 @@ pub use rw_lock::*;
 #[cfg(feature = "once")]
 pub use once::*;
 
+mod lock;
+mod spinlock;
 mod mutex;
 mod rw_lock;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@ mod rw_lock;
 
 pub use lock::*;
 pub use spinlock::*;
+pub use util::*;
 
 #[cfg(feature = "once")]
 mod once;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,9 +26,9 @@ mod rw_lock;
 
 pub use lock::*;
 pub use spinlock::*;
-pub use util::*;
 
 #[cfg(feature = "once")]
 mod once;
 
 mod util;
+pub use util::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,9 @@ mod spinlock;
 mod mutex;
 mod rw_lock;
 
+pub use lock::*;
+pub use spinlock::*;
+
 #[cfg(feature = "once")]
 mod once;
 

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -1,6 +1,14 @@
+
+/// Public abstraction for a lock implementation.
 pub trait Lock
 {
+	/// true when a lock is acquired successfully
+	/// false otherwise
     fn try_lock(&self) -> bool;
+    
+    /// obtain a lock
     fn lock(&self);
+    
+    /// release a lock
     fn unlock(&self);
 }

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -1,0 +1,6 @@
+pub trait Lock
+{
+    fn try_lock(&self) -> bool;
+    fn lock(&self);
+    fn unlock(&self);
+}

--- a/src/once.rs
+++ b/src/once.rs
@@ -197,7 +197,7 @@ mod tests {
     #[test]
     fn stampede_once() {
         static O: Once<()> = Once::new();
-        static mut run: bool = false;
+        static mut RUN: bool = false;
 
         let (tx, rx) = channel();
         for _ in 0..10 {
@@ -206,10 +206,10 @@ mod tests {
                 for _ in 0..4 { thread::yield_now() }
                 unsafe {
                     O.call_once(|| {
-                        assert!(!run);
-                        run = true;
+                        assert!(!RUN);
+                        RUN = true;
                     });
-                    assert!(run);
+                    assert!(RUN);
                 }
                 tx.send(()).unwrap();
             });
@@ -217,10 +217,10 @@ mod tests {
 
         unsafe {
             O.call_once(|| {
-                assert!(!run);
-                run = true;
+                assert!(!RUN);
+                RUN = true;
             });
-            assert!(run);
+            assert!(RUN);
         }
 
         for _ in 0..10 {

--- a/src/spinlock.rs
+++ b/src/spinlock.rs
@@ -1,0 +1,61 @@
+use core::sync::atomic::{AtomicBool, Ordering, ATOMIC_BOOL_INIT};
+use core::marker::Sync;
+use core::default::Default;
+use lock::Lock;
+use util::cpu_relax;
+
+pub struct SpinLock
+{
+    lock: AtomicBool,
+}
+
+unsafe impl Sync for SpinLock {}
+unsafe impl Send for SpinLock {}
+
+impl SpinLock
+{
+    #[cfg(feature = "const_fn")]
+    pub const fn new() -> SpinLock
+    {
+        SpinLock { lock: ATOMIC_BOOL_INIT }
+    }
+
+    #[cfg(not(feature = "const_fn"))]
+    pub fn new() -> SpinLock
+    {
+        SpinLock { lock: ATOMIC_BOOL_INIT }
+    }
+}
+
+impl Lock for SpinLock
+{
+    #[inline]
+    fn try_lock(&self) -> bool
+    {
+        self.lock
+            .compare_and_swap(false, true, Ordering::Acquire) == false
+    }
+
+    #[inline]
+    fn lock(&self)
+    {
+        while !self.try_lock()
+        {
+            cpu_relax();
+        }
+    }
+
+    #[inline]
+    fn unlock(&self)
+    {
+        self.lock.store(false, Ordering::Release);
+    }
+}
+
+impl Default for SpinLock
+{
+    fn default() -> SpinLock
+    {
+        SpinLock::new()
+    }
+}

--- a/src/spinlock.rs
+++ b/src/spinlock.rs
@@ -4,6 +4,7 @@ use core::default::Default;
 use lock::Lock;
 use util::cpu_relax;
 
+/// This type provides Lock based on spinning.
 pub struct SpinLock
 {
     lock: AtomicBool,
@@ -14,12 +15,18 @@ unsafe impl Send for SpinLock {}
 
 impl SpinLock
 {
+	/// Creates a new spinlock without data.
+    ///
+    /// May be used statically:
     #[cfg(feature = "const_fn")]
     pub const fn new() -> SpinLock
     {
         SpinLock { lock: ATOMIC_BOOL_INIT }
     }
 
+	/// Creates a new spinlock without data.
+    ///
+    /// If you want to use it statically, you can use the `const_fn` feature.
     #[cfg(not(feature = "const_fn"))]
     pub fn new() -> SpinLock
     {


### PR DESCRIPTION
Separate the spinlock implementation for users who want to use the spinlock primitive to implement their own synchronization primitives.
