### PR TITLE
Fix compilation failure on nightly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,8 @@
 #![cfg_attr(feature = "asm", feature(asm))]
 #![cfg_attr(feature = "core_intrinsics", feature(core_intrinsics))]
 #![cfg_attr(feature = "const_fn", feature(const_fn))]
+#![cfg_attr(feature = "const_fn", feature(const_unsafe_cell_new))]
+#![cfg_attr(feature = "const_fn", feature(const_atomic_usize_new))]
 
 #![no_std]
 


### PR DESCRIPTION
Fixes #43 by adding features for const fn initializers.