### PR TITLE
Wrong Sync + Sync bound in Once

### DIFF
--- a/src/once.rs
+++ b/src/once.rs
@@ -27,8 +27,8 @@ pub struct Once<T> {
 
 // Same unsafe impls as `std::sync::RwLock`, because this also allows for
 // concurrent reads.
-unsafe impl<T: Sync + Sync> Sync for Once<T> {}
-unsafe impl<T: Sync + Sync> Send for Once<T> {}
+unsafe impl<T: Send + Sync> Sync for Once<T> {}
+unsafe impl<T: Send + Sync> Send for Once<T> {}
 
 // Four states that a Once can be in, encoded into the lower bits of `state` in
 // the Once structure.


### PR DESCRIPTION
While looking at the implementation of `Once`, I saw this oddity. I figured it couldn't possibly be right. The comment mentions it has the same bounds as RwLock, which has Send + Sync. I suppose it's a typo?