### PR TITLE
Fix compile error on nightly-2018-08-14

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 
 //! Synchronization primitives based on spinning
 
-#![cfg_attr(feature = "const_fn", feature(const_fn, const_unsafe_cell_new, const_atomic_usize_new))]
+#![cfg_attr(feature = "const_fn", feature(const_fn))]
 
 #![no_std]
 


### PR DESCRIPTION
`const_unsafe_cell_new` and `const_atomic_usize_new` are stable now and don't need to be enabled by feature.