### PR TITLE
added Once constant initialization via constant

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,6 @@ and static initializers are available.
 
 [features]
 const_fn = []
-once = ["const_fn"]
+once = []
 unstable = ["const_fn", "once"]
 default = ["unstable"]


### PR DESCRIPTION
Added Once constant initialization via constant. This allows `Once` to be used on stable Rust with constant initialization.