### PR TITLE
Add missing Derive(Debug)

### DIFF
--- a/src/once.rs
+++ b/src/once.rs
@@ -18,6 +18,7 @@ use core::sync::atomic::{AtomicUsize, Ordering, spin_loop_hint as cpu_relax};
 ///     // run initialization here
 /// });
 /// ```
+#[derive(Debug)]
 pub struct Once<T> {
     state: AtomicUsize,
     data: UnsafeCell<Option<T>>, // TODO remove option and use mem::uninitialized

--- a/src/once.rs
+++ b/src/once.rs
@@ -1,5 +1,6 @@
 use core::cell::UnsafeCell;
 use core::sync::atomic::{AtomicUsize, Ordering, spin_loop_hint as cpu_relax};
+use core::fmt;
 
 /// A synchronization primitive which can be used to run a one-time global
 /// initialization. Unlike its std equivalent, this is generalized so that The
@@ -18,10 +19,18 @@ use core::sync::atomic::{AtomicUsize, Ordering, spin_loop_hint as cpu_relax};
 ///     // run initialization here
 /// });
 /// ```
-#[derive(Debug)]
 pub struct Once<T> {
     state: AtomicUsize,
     data: UnsafeCell<Option<T>>, // TODO remove option and use mem::uninitialized
+}
+
+impl<T: fmt::Debug> fmt::Debug for Once<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self.try() {
+            Some(s) => write!(f, "Once {{ data: {:?} }}", s),
+            None => write!(f, "Once {{ <uninitialized> }}")
+        }
+    }
 }
 
 // Same unsafe impls as `std::sync::RwLock`, because this also allows for

--- a/src/rw_lock.rs
+++ b/src/rw_lock.rs
@@ -52,6 +52,7 @@ pub struct RwLock<T: ?Sized>
 ///
 /// When the guard falls out of scope it will decrement the read count,
 /// potentially releasing the lock.
+#[derive(Debug)]
 pub struct RwLockReadGuard<'a, T: 'a + ?Sized>
 {
     lock: &'a AtomicUsize,
@@ -61,6 +62,7 @@ pub struct RwLockReadGuard<'a, T: 'a + ?Sized>
 /// A guard to which the protected data can be written
 ///
 /// When the guard falls out of scope it will release the lock.
+#[derive(Debug)]
 pub struct RwLockWriteGuard<'a, T: 'a + ?Sized>
 {
     lock: &'a AtomicUsize,


### PR DESCRIPTION
Adds some useful Debug implementations for Once, RwLockReadGuard and RwLockWriteGuard.

Maybe this project should have `#![deny(missing_debug_impl)]` ?