### PR TITLE
Debug keeps formatting

### DIFF
--- a/src/mutex.rs
+++ b/src/mutex.rs
@@ -226,7 +226,9 @@ impl<T: ?Sized + fmt::Debug> fmt::Debug for Mutex<T>
     {
         match self.try_lock()
         {
-            Some(guard) => write!(f, "Mutex {{ data: {:?} }}", &*guard),
+            Some(guard) => write!(f, "Mutex {{ data: ")
+				.and_then(|()| (&*guard).fmt(f))
+				.and_then(|()| write!(f, "}}")),
             None => write!(f, "Mutex {{ <locked> }}"),
         }
     }

--- a/src/once.rs
+++ b/src/once.rs
@@ -27,7 +27,9 @@ pub struct Once<T> {
 impl<T: fmt::Debug> fmt::Debug for Once<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self.try() {
-            Some(s) => write!(f, "Once {{ data: {:?} }}", s),
+            Some(s) => write!(f, "Once {{ data: ")
+				.and_then(|()| s.fmt(f))
+				.and_then(|()| write!(f, "}}")),
             None => write!(f, "Once {{ <uninitialized> }}")
         }
     }

--- a/src/rw_lock.rs
+++ b/src/rw_lock.rs
@@ -345,7 +345,9 @@ impl<T: ?Sized + fmt::Debug> fmt::Debug for RwLock<T>
     {
         match self.try_read()
         {
-            Some(guard) => write!(f, "RwLock {{ data: {:?} }}", &*guard),
+            Some(guard) => write!(f, "RwLock {{ data: ")
+                .and_then(|()| (&*guard).fmt(f))
+                .and_then(|()| write!(f, "}}")),
             None => write!(f, "RwLock {{ <locked> }}"),
         }
     }


### PR DESCRIPTION
Displaying a lock with {:x?} or {:#?} propagates desired formatting to the locked data.