### PR TITLE
Remove need for const_fn feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,5 @@ and static initializers are available.
 """
 
 [features]
-const_fn = []
 once = []
-unstable = ["const_fn", "once"]
-default = ["unstable"]
+default = ["once"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,6 @@ documentation = "https://mvdnes.github.io/rust-docs/spin-rs/spin/index.html"
 keywords = ["spinlock", "mutex", "rwlock"]
 description = """
 Synchronization primitives based on spinning.
-They may contain data,
-They are usable without `std`
+They may contain data, they are usable without `std`,
 and static initializers are available.
 """
-
-[features]
-once = []
-default = ["once"]

--- a/README.md
+++ b/README.md
@@ -15,8 +15,6 @@ Usage
 By default this crate only works on nightly but you can disable the default features
 if you want to run on stable. Nightly is more efficient than stable currently.
 
-Also, `Once` is only available on nightly as it is only useful when `const_fn` is available.
-
 Include the following code in your Cargo.toml
 
 ```toml

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,8 +3,6 @@
 
 //! Synchronization primitives based on spinning
 
-#![cfg_attr(feature = "const_fn", feature(const_fn))]
-
 #![no_std]
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,12 +11,8 @@ extern crate std;
 
 pub use mutex::*;
 pub use rw_lock::*;
-
-#[cfg(feature = "once")]
 pub use once::*;
 
 mod mutex;
 mod rw_lock;
-
-#[cfg(feature = "once")]
 mod once;

--- a/src/mutex.rs
+++ b/src/mutex.rs
@@ -96,7 +96,6 @@ impl<T> Mutex<T>
     /// May be used statically:
     ///
     /// ```
-    /// #![feature(const_fn)]
     /// use spin;
     ///
     /// static MUTEX: spin::Mutex<()> = spin::Mutex::new(());
@@ -107,32 +106,7 @@ impl<T> Mutex<T>
     ///     drop(lock);
     /// }
     /// ```
-    #[cfg(feature = "const_fn")]
     pub const fn new(user_data: T) -> Mutex<T>
-    {
-        Mutex
-        {
-            lock: ATOMIC_BOOL_INIT,
-            data: UnsafeCell::new(user_data),
-        }
-    }
-
-    /// Creates a new spinlock wrapping the supplied data.
-    ///
-    /// If you want to use it statically, you can use the `const_fn` feature.
-    ///
-    /// ```
-    /// use spin;
-    ///
-    /// fn demo() {
-    ///     let mutex = spin::Mutex::new(());
-    ///     let lock = mutex.lock();
-    ///     // do something with lock
-    ///     drop(lock);
-    /// }
-    /// ```
-    #[cfg(not(feature = "const_fn"))]
-    pub fn new(user_data: T) -> Mutex<T>
     {
         Mutex
         {
@@ -282,7 +256,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "const_fn")]
     fn lots_and_lots() {
         static M: Mutex<()>  = Mutex::new(());
         static mut CNT: u32 = 0;

--- a/src/once.rs
+++ b/src/once.rs
@@ -10,7 +10,6 @@ use core::fmt;
 /// # Examples
 ///
 /// ```
-/// #![feature(const_fn)]
 /// use spin;
 ///
 /// static START: spin::Once<()> = spin::Once::new();
@@ -57,14 +56,7 @@ impl<T> Once<T> {
     };
 
     /// Creates a new `Once` value.
-    #[cfg(feature = "const_fn")]
     pub const fn new() -> Once<T> {
-        Self::INIT
-    }
-
-    /// Creates a new `Once` value.
-    #[cfg(not(feature = "const_fn"))]
-    pub fn new() -> Once<T> {
         Self::INIT
     }
 
@@ -90,7 +82,6 @@ impl<T> Once<T> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(const_fn)]
     /// use spin;
     ///
     /// static INIT: spin::Once<usize> = spin::Once::new();

--- a/src/rw_lock.rs
+++ b/src/rw_lock.rs
@@ -82,7 +82,6 @@ impl<T> RwLock<T>
     /// May be used statically:
     ///
     /// ```
-    /// #![feature(const_fn)]
     /// use spin;
     ///
     /// static RW_LOCK: spin::RwLock<()> = spin::RwLock::new(());
@@ -94,33 +93,7 @@ impl<T> RwLock<T>
     /// }
     /// ```
     #[inline]
-    #[cfg(feature = "const_fn")]
     pub const fn new(user_data: T) -> RwLock<T>
-    {
-        RwLock
-        {
-            lock: ATOMIC_USIZE_INIT,
-            data: UnsafeCell::new(user_data),
-        }
-    }
-
-    /// Creates a new spinlock wrapping the supplied data.
-    ///
-    /// If you want to use it statically, you can use the `const_fn` feature.
-    ///
-    /// ```
-    /// use spin;
-    ///
-    /// fn demo() {
-    ///     let rw_lock = spin::RwLock::new(());
-    ///     let lock = rw_lock.read();
-    ///     // do something with lock
-    ///     drop(lock);
-    /// }
-    /// ```
-    #[inline]
-    #[cfg(not(feature = "const_fn"))]
-    pub fn new(user_data: T) -> RwLock<T>
     {
         RwLock
         {


### PR DESCRIPTION
Given the recent merge to stable of `const_fn`, a feature flag is no longer necessary.