### PR TITLE
Prepare for a 0.5.0 release?

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "spin"
-version = "0.4.10"
+version = "0.5.0"
 authors = [ "Mathijs van de Nes <git@mathijs.vd-nes.nl>",
             "John Ericson <John_Ericson@Yahoo.com>" ]
 license = "MIT"
@@ -10,6 +10,6 @@ documentation = "https://mvdnes.github.io/rust-docs/spin-rs/spin/index.html"
 keywords = ["spinlock", "mutex", "rwlock"]
 description = """
 Synchronization primitives based on spinning.
-They may contain data, they are usable without `std`,
+They may contain data, are usable without `std`,
 and static initializers are available.
 """

--- a/README.md
+++ b/README.md
@@ -3,25 +3,19 @@ spin-rs
 
 [![Build Status](https://travis-ci.org/mvdnes/spin-rs.svg)](https://travis-ci.org/mvdnes/spin-rs)
 [![Crates.io version](https://img.shields.io/crates/v/spin.svg)](https://crates.io/crates/spin)
-
-[Documentation](https://mvdnes.github.io/rust-docs/spin-rs/spin/index.html)
+[![docs.rs](https://docs.rs/spin/badge.svg)](https://docs.rs/spin/)
 
 This Rust library implements a simple
-[spinlock](https://en.wikipedia.org/wiki/Spinlock).
+[spinlock](https://en.wikipedia.org/wiki/Spinlock), and is safe for `#[no_std]` environments.
 
 Usage
 -----
-
-By default this crate only works on nightly but you can disable the default features
-if you want to run on stable. Nightly is more efficient than stable currently.
 
 Include the following code in your Cargo.toml
 
 ```toml
 [dependencies.spin]
-version = "0.4"
-# If you want to run on stable you will need to add the following:
-# default-features = false
+version = "0.5"
 ```
 
 Example


### PR DESCRIPTION
Is it OK to bump the version given recent release of Rust 2018? I'd like to make use of this crate in a `stable` environment.