### PR TITLE
Remove deprecated ATOMIC_USIZE_INIT and ATOMIC_BOOL_INIT

### DIFF
--- a/src/mutex.rs
+++ b/src/mutex.rs
@@ -1,4 +1,4 @@
-use core::sync::atomic::{AtomicBool, Ordering, ATOMIC_BOOL_INIT, spin_loop_hint as cpu_relax};
+use core::sync::atomic::{AtomicBool, Ordering, spin_loop_hint as cpu_relax};
 use core::cell::UnsafeCell;
 use core::marker::Sync;
 use core::ops::{Drop, Deref, DerefMut};
@@ -110,7 +110,7 @@ impl<T> Mutex<T>
     {
         Mutex
         {
-            lock: ATOMIC_BOOL_INIT,
+            lock: AtomicBool::new(false),
             data: UnsafeCell::new(user_data),
         }
     }

--- a/src/rw_lock.rs
+++ b/src/rw_lock.rs
@@ -1,4 +1,4 @@
-use core::sync::atomic::{AtomicUsize, Ordering, ATOMIC_USIZE_INIT, spin_loop_hint as cpu_relax};
+use core::sync::atomic::{AtomicUsize, Ordering, spin_loop_hint as cpu_relax};
 use core::cell::UnsafeCell;
 use core::ops::{Deref, DerefMut};
 use core::fmt;
@@ -97,7 +97,7 @@ impl<T> RwLock<T>
     {
         RwLock
         {
-            lock: ATOMIC_USIZE_INIT,
+            lock: AtomicUsize::new(0),
             data: UnsafeCell::new(user_data),
         }
     }


### PR DESCRIPTION
warning: use of deprecated item 'core::sync::atomic::ATOMIC_USIZE_INIT': the new function is now preferred