### PR TITLE
Rewrite RwLock to use folly upgradeable implementation

### DIFF
--- a/src/rw_lock.rs
+++ b/src/rw_lock.rs
@@ -28,6 +28,11 @@ use core::sync::atomic::{spin_loop_hint as cpu_relax, AtomicUsize, Ordering};
 ///
 /// Based on Facebook's
 /// [`folly/RWSpinLock.h`](https://github.com/facebook/folly/blob/a0394d84f2d5c3e50ebfd0566f9d3acb52cfab5a/folly/synchronization/RWSpinLock.h).
+/// This implementation is unfair to writers - if the lock always has readers, then no writers will
+/// ever get a chance. Using an upgradeable lock guard can *somewhat* alleviate this issue as no
+/// new readers are allowed when an upgradeable guard is held, but upgradeable guards can be taken
+/// when there are existing readers. However if the lock is that highly contended and writes are
+/// crucial then this implementation may be a poor choice.
 ///
 /// # Examples
 ///

--- a/src/rw_lock.rs
+++ b/src/rw_lock.rs
@@ -302,7 +302,7 @@ impl<T: ?Sized> RwLock<T> {
     /// ```
     #[inline]
     pub fn try_write(&self) -> Option<RwLockWriteGuard<T>> {
-        self.try_write_internal(false)
+        self.try_write_internal(true)
     }
 
     /// Obtain a readable lock guard that can later be upgraded to a writable lock guard.

--- a/src/rw_lock.rs
+++ b/src/rw_lock.rs
@@ -56,8 +56,8 @@ pub struct RwLock<T: ?Sized> {
     data: UnsafeCell<T>,
 }
 
-const READER: usize = 4;
-const UPGRADED: usize = 2;
+const READER: usize = 1 << 2;
+const UPGRADED: usize = 1 << 1;
 const WRITER: usize = 1;
 
 /// A guard from which the protected data can be read


### PR DESCRIPTION
Fixes #65.

I fully expect there to be some issues with this, so I'm going to get a few more eyes to look over it.

I've done a very quick performance test with the parking lot benchmarks:
```
$ cargo run --bin rwlock --release 1 3 100 10000 10 5
spin::RwLock (new)   - [write]     43.180 kHz [read]    129.347 kHz
spin::RwLock (old)   - [write]     43.146 kHz [read]    129.297 kHz
```

I genuinely have no idea whether those arguments make for a good test lol. Happy to rerun with something else.

Also not sure how you want to handle semver here.