### PR TITLE
Add get_mut to Mutex and RwLock

### DIFF
--- a/src/mutex.rs
+++ b/src/mutex.rs
@@ -192,6 +192,24 @@ impl<T: ?Sized> Mutex<T>
             None
         }
     }
+
+    /// Returns a mutable reference to the underlying data.
+    ///
+    /// Since this call borrows the `Mutex` mutably, no actual locking needs to
+    /// take place -- the mutable borrow statically guarantees no locks exist.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let mut my_lock = spin::Mutex::new(0);
+    /// *my_lock.get_mut() = 10;
+    /// assert_eq!(*my_lock.lock(), 10);
+    /// ```
+    pub fn get_mut(&mut self) -> &mut T {
+        // We know statically that there are no other references to `self`, so
+        // there's no need to lock the inner mutex.
+        unsafe { &mut *self.data.get() }
+    }
 }
 
 impl<T: ?Sized + fmt::Debug> fmt::Debug for Mutex<T>

--- a/src/rw_lock.rs
+++ b/src/rw_lock.rs
@@ -337,6 +337,24 @@ impl<T: ?Sized> RwLock<T> {
             None
         }
     }
+
+   /// Returns a mutable reference to the underlying data.
+   ///
+   /// Since this call borrows the `RwLock` mutably, no actual locking needs to
+   /// take place -- the mutable borrow statically guarantees no locks exist.
+   ///
+   /// # Examples
+   ///
+   /// ```
+   /// let mut lock = spin::RwLock::new(0);
+   /// *lock.get_mut() = 10;
+   /// assert_eq!(*lock.read(), 10);
+   /// ```
+    pub fn get_mut(&mut self) -> &mut T {
+        // We know statically that there are no other references to `self`, so
+        // there's no need to lock the inner lock.
+        unsafe { &mut *self.data.get() }
+    }
 }
 
 impl<T: ?Sized + fmt::Debug> fmt::Debug for RwLock<T> {


### PR DESCRIPTION
When holding a `&mut` to a lock, you statically know from the type checker that you hold the only reference to the lock at that time, and that no guard exists.
You can therefor by-pass the locking and access the wrapped data directly.

This commit simply copy-pastes `std::sync::Mutex::get_mut` and `std::sync::RwLock::get_mut` implementations, removing poisons.