### PR TITLE
Removed unsound guard Sync impls

### DIFF
--- a/src/mutex.rs
+++ b/src/mutex.rs
@@ -86,8 +86,7 @@ pub struct MutexGuard<'a, T: ?Sized + 'a>
 }
 
 // These are safe because access to the inner data is determined by the atomic and is not dependent on the thread model
-unsafe impl<'a, T: ?Sized> Send for MutexGuard<'a, T> where &'a T: Send {}
-unsafe impl<'a, T: ?Sized> Sync for MutexGuard<'a, T> where &'a T: Send {}
+unsafe impl<'a, T: ?Sized> Send for MutexGuard<'a, T> where &'a mut T: Send {}
 
 // Same unsafe impls as `std::sync::Mutex`
 unsafe impl<T: ?Sized + Send> Sync for Mutex<T> {}

--- a/src/rw_lock.rs
+++ b/src/rw_lock.rs
@@ -91,8 +91,7 @@ pub struct RwLockWriteGuard<'a, T: 'a + ?Sized> {
 }
 
 // These are safe because access to the inner data is determined by the atomic and is not dependent on the thread model
-unsafe impl<'a, T: ?Sized> Send for RwLockWriteGuard<'a, T> where &'a T: Send {}
-unsafe impl<'a, T: ?Sized> Sync for RwLockWriteGuard<'a, T> where &'a T: Sync {}
+unsafe impl<'a, T: ?Sized> Send for RwLockWriteGuard<'a, T> where &'a mut T: Send {}
 
 /// A guard from which the protected data can be read, and can be upgraded
 /// to a writable guard if needed


### PR DESCRIPTION
I wasn't thinking through my past changes properly. This PR removed those guard trait impls that are unsound.