### PR TITLE
Fix license inconsistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,5 +93,4 @@ accessed. Instead, they will 'spin' in a busy loop until the lock becomes availa
 
 ## License
 
-`spin` is distributed under the Apache License, Version 2.0, (See `LICENSE` or
-https://www.apache.org/licenses/LICENSE-2.0).
+`spin` is distributed under the MIT License, (See `LICENSE`).


### PR DESCRIPTION
Spin is licensed under MIT, but the README states that it's
licensed under Apache 2.0. Update the README to be consistent with
LICENSE.