### PR TITLE
Implement condition variable

### DIFF
--- a/src/condvar.rs
+++ b/src/condvar.rs
@@ -1,0 +1,141 @@
+//! A condition variable based on spinning.
+
+use {
+    crate::{Mutex, MutexGuard},
+    core::{
+        mem, ptr,
+        sync::atomic::{AtomicBool, Ordering},
+    },
+};
+
+/// A condition variable based on spinning.
+pub struct Condvar {
+    head: Mutex<WaiterPtr>,
+}
+
+impl Condvar {
+    /// Create a new condition variable.
+    pub const fn new() -> Self {
+        Self {
+            head: Mutex::new(WaiterPtr(ptr::null())),
+        }
+    }
+
+    /// Notify at most one waiter. Returns `true` if a waiter was notified, and
+    /// `false` otherwise.
+    pub fn notify_one(&self) -> bool {
+        let mut head = self.head.lock();
+        Self::notify_one_locked(&mut head)
+    }
+
+    /// Notify all waiters. Returns the number of waiters that were notified.
+    pub fn notify_all(&self) -> usize {
+        let mut head = self.head.lock();
+        let mut count = 0;
+        while Self::notify_one_locked(&mut head) {
+            count += 1;
+        }
+        count
+    }
+
+    /// Atomically drop `guard` and start waiting until notified. Upon being
+    /// notified, re-acquire a new `MutexGuard` and return it.
+    pub fn wait<'a, T>(&self, mutex: &'a Mutex<T>, guard: MutexGuard<'a, T>) -> MutexGuard<'a, T>
+    where
+        T: 'a + ?Sized,
+    {
+        let mut head = self.head.lock();
+        let waiter = Waiter {
+            next: *head,
+            wait: AtomicBool::new(true),
+        };
+        *head = WaiterPtr(&waiter);
+        mem::drop(head);
+
+        mem::drop(guard);
+
+        while waiter.wait.load(Ordering::SeqCst) {
+            crate::relax();
+        }
+
+        mutex.lock()
+    }
+
+    fn notify_one_locked(head: &mut WaiterPtr) -> bool {
+        if head.0.is_null() {
+            false
+        } else {
+            let w = head.0;
+
+            // SAFETY: `w` is guaranteed not to be dangling because waiter is
+            // spinning on `w.wait`.
+            *head = unsafe { &*w }.next;
+
+            // SAFETY: `w` is guaranteed not to be dangling because waiter is
+            // spinning on `w.wait`.
+            unsafe { &*w }.wait.store(false, Ordering::SeqCst);
+            // NOTE: After the store above completes, `w` may be dangling.
+
+            true
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+struct WaiterPtr(*const Waiter);
+
+unsafe impl Send for WaiterPtr {}
+
+struct Waiter {
+    next: WaiterPtr,
+    wait: AtomicBool,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::prelude::v1::*;
+
+    use std::sync::Arc;
+    use std::thread;
+
+    use super::*;
+
+    #[test]
+    fn smoke() {
+        let m = Arc::new(Mutex::new(()));
+        let c = Arc::new(Condvar::new());
+        let t = {
+            let c = c.clone();
+            thread::spawn(move || {
+                c.notify_one();
+            })
+        };
+        let g = m.lock();
+        c.wait(&m, g);
+        t.join().expect("Failed to join.");
+    }
+
+    #[test]
+    fn wait_for_condition() {
+        let m = Arc::new(Mutex::new(0i32));
+        let c = Arc::new(Condvar::new());
+        let t = {
+            let m = m.clone();
+            let c = c.clone();
+            thread::spawn(move || {
+                for _ in 0..5 {
+                    {
+                        let mut g = m.lock();
+                        *g += 1;
+                    }
+                    c.notify_one();
+                }
+            })
+        };
+        let mut g = m.lock();
+        while *g != 5 {
+            g = c.wait(&*m, g);
+        }
+        t.join().expect("Failed to join.");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,6 +62,7 @@ use core::sync::atomic::spin_loop_hint as relax;
 use std::thread::yield_now as relax;
 
 pub mod barrier;
+pub mod condvar;
 pub mod lazy;
 pub mod mutex;
 pub mod once;
@@ -70,6 +71,7 @@ pub mod rw_lock;
 pub use barrier::Barrier;
 pub use lazy::Lazy;
 pub use mutex::{Mutex, MutexGuard};
+pub use condvar::Condvar;
 pub use once::Once;
 pub use rw_lock::{RwLock, RwLockReadGuard, RwLockWriteGuard, RwLockUpgradableGuard};
 

--- a/src/mutex.rs
+++ b/src/mutex.rs
@@ -102,9 +102,9 @@ unsafe impl<T: ?Sized + Send> Send for Mutex<T> {}
 /// [`SpinMutexGuard`]: ./struct.SpinMutexGuard.html
 pub struct MutexGuard<'a, T: 'a + ?Sized> {
     #[cfg(feature = "ticket_mutex")]
-    pub(crate) inner: TicketMutexGuard<'a, T>,
+    inner: TicketMutexGuard<'a, T>,
     #[cfg(not(feature = "ticket_mutex"))]
-    pub(crate) inner: SpinMutexGuard<'a, T>,
+    inner: SpinMutexGuard<'a, T>,
 }
 
 impl<T> Mutex<T> {

--- a/src/mutex.rs
+++ b/src/mutex.rs
@@ -102,9 +102,9 @@ unsafe impl<T: ?Sized + Send> Send for Mutex<T> {}
 /// [`SpinMutexGuard`]: ./struct.SpinMutexGuard.html
 pub struct MutexGuard<'a, T: 'a + ?Sized> {
     #[cfg(feature = "ticket_mutex")]
-    inner: TicketMutexGuard<'a, T>,
+    pub(crate) inner: TicketMutexGuard<'a, T>,
     #[cfg(not(feature = "ticket_mutex"))]
-    inner: SpinMutexGuard<'a, T>,
+    pub(crate) inner: SpinMutexGuard<'a, T>,
 }
 
 impl<T> Mutex<T> {


### PR DESCRIPTION
Closes #31. I took a stab at implementing this, but I think this PR stills needs quite a bit of work to get into a state where this could be added to the library, but I don't have as much time to work on this as I was hoping and I wanted to get the work I'd already done out there in case anyone else wants to pick this up.

I considered a few different designs (prototyped with C++11 and linked below), all of which revolve around having waiting threads spin on their own separate atomic variable to minimize contention and spurious wakes, and forming a linked-list of waiting threads using their call stacks:
- First, a design which uses an internal spin lock to synchronize the linked-list: https://github.com/akiekintveld/spin_condvar/blob/main/spin_condvar.cc
- Second, a design that avoids an internal spin lock by requiring that calls to signal/notify hold the mutex being waited on to protect the linked-list (this is a slight change to the usual interface that would follow stricter Mesa monitor semantics): https://github.com/akiekintveld/spin_condvar/blob/mesa/spin_condvar.cc
- Third, a design that avoids an internal spin lock by carefully manipulating the linked list using atomics: https://github.com/akiekintveld/spin_condvar/blob/lock_free/spin_condvar.cc
- Fourth, a design I didn't have time to fully think through, which would use two counters in a similar manner to a ticket lock to get condition variable semantics.

While the last three designs are interesting, there are aspects that make them more difficult to express safely in Rust, so I decided to try the first design. I wrote a few unit tests to verify that it works as expected, but there are still some parts I am unsure of.