### PR TITLE
Once: Don't leak internal value when Once goes out of scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+### Fixed
+
+- `Fix Once leaking the inner object when it goes out of scope`
+
 # [0.7.0] - 2020-10-18
 
 ### Added


### PR DESCRIPTION
When Once goes out of scope, contained value will be leaked, since MaybeUninit requires manual dropping.

This patch implements Drop for Once and drops the value if it was previously initialized.