### PR TITLE
Added relax strategy parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `Once::get_unchecked`
-
 ### Changed
 
 ### Fixed
+
+# [0.8.0] - 2021-03-15
+
+### Added
+
+- `Once::get_unchecked`
+- `RelaxStrategy` trait with type parameter on all locks to support switching between relax strategies.
+
+### Changed
+
+- `lock_api1` feature is now named `lock_api`
 
 # [0.7.1] - 2021-01-12
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,5 @@ description = "Spin-based synchronization primitives"
 lock_api_crate = { package = "lock_api", version = "0.4", optional = true }
 
 [features]
-default = ["ticket_mutex"]
 lock_api = ["lock_api_crate"]
-ticket_mutex = []
 std = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spin"
-version = "0.7.1"
+version = "0.8.0"
 authors = [
 	"Mathijs van de Nes <git@mathijs.vd-nes.nl>",
 	"John Ericson <git@JohnEricson.me>",

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ spinlocks. If you have access to `std`, it's likely that the primitives in
 - Upgradeable `RwLock` guards
 - Guards can be sent and shared between threads
 - Guard leaking
-- `std` feature to enable yield to the OS scheduler in busy loops
-- `Mutex` can become a ticket lock
+- Ticket locks
+- Different strategies for dealing with contention
 
 ## Usage
 

--- a/examples/debug.rs
+++ b/examples/debug.rs
@@ -1,14 +1,14 @@
 extern crate spin;
 
 fn main() {
-    let mutex = spin::Mutex::new(42);
+    let mutex = spin::Mutex::<_>::new(42);
     println!("{:?}", mutex);
     {
         let x = mutex.lock();
         println!("{:?}, {:?}", mutex, *x);
     }
 
-    let rwlock = spin::RwLock::new(42);
+    let rwlock = spin::RwLock::<_>::new(42);
     println!("{:?}", rwlock);
     {
         let x = rwlock.read();

--- a/examples/debug.rs
+++ b/examples/debug.rs
@@ -1,14 +1,14 @@
 extern crate spin;
 
 fn main() {
-    let mutex = spin::Mutex::<_>::new(42);
+    let mutex = spin::Mutex::new(42);
     println!("{:?}", mutex);
     {
         let x = mutex.lock();
         println!("{:?}, {:?}", mutex, *x);
     }
 
-    let rwlock = spin::RwLock::<_>::new(42);
+    let rwlock = spin::RwLock::new(42);
     println!("{:?}", rwlock);
     {
         let x = rwlock.read();

--- a/src/barrier.rs
+++ b/src/barrier.rs
@@ -7,16 +7,14 @@
 //! Copyright 2014 The Rust Project Developers. See the COPYRIGHT
 //! file at the top-level directory of this distribution and at
 //! http://rust-lang.org/COPYRIGHT.
-//! 
+//!
 //! Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 //! http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
 //! <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 //! option. This file may not be copied, modified, or distributed
 //! except according to those terms.
 
-use core::sync::atomic::spin_loop_hint as cpu_relax;
-
-use crate::Mutex;
+use crate::{Mutex, RelaxStrategy, Spin};
 
 /// A primitive that synchronizes the execution of multiple threads.
 ///
@@ -44,8 +42,8 @@ use crate::Mutex;
 ///     handle.join().unwrap();
 /// }
 /// ```
-pub struct Barrier {
-    lock: Mutex<BarrierState>,
+pub struct Barrier<R = Spin> {
+    lock: Mutex<BarrierState, R>,
     num_threads: usize,
 }
 
@@ -71,32 +69,7 @@ struct BarrierState {
 /// ```
 pub struct BarrierWaitResult(bool);
 
-impl Barrier {
-    /// Creates a new barrier that can block a given number of threads.
-    ///
-    /// A barrier will block `n`-1 threads which call [`wait`] and then wake up
-    /// all threads at once when the `n`th thread calls [`wait`]. A Barrier created
-    /// with n = 0 will behave identically to one created with n = 1.
-    ///
-    /// [`wait`]: #method.wait
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use spin;
-    ///
-    /// let barrier = spin::Barrier::new(10);
-    /// ```
-    pub const fn new(n: usize) -> Barrier {
-        Barrier {
-            lock: Mutex::new(BarrierState {
-                count: 0,
-                generation_id: 0,
-            }),
-            num_threads: n,
-        }
-    }
-
+impl<R: RelaxStrategy> Barrier<R> {
     /// Blocks the current thread until all threads have rendezvoused here.
     ///
     /// Barriers are re-usable after all threads have rendezvoused once, and can
@@ -145,7 +118,7 @@ impl Barrier {
             while local_gen == lock.generation_id &&
                 lock.count < self.num_threads {
                 drop(lock);
-                cpu_relax();
+                R::relax();
                 lock = self.lock.lock();
             }
             BarrierWaitResult(false)
@@ -155,6 +128,33 @@ impl Barrier {
             lock.count = 0;
             lock.generation_id = lock.generation_id.wrapping_add(1);
             BarrierWaitResult(true)
+        }
+    }
+}
+
+impl<R> Barrier<R> {
+    /// Creates a new barrier that can block a given number of threads.
+    ///
+    /// A barrier will block `n`-1 threads which call [`wait`] and then wake up
+    /// all threads at once when the `n`th thread calls [`wait`]. A Barrier created
+    /// with n = 0 will behave identically to one created with n = 1.
+    ///
+    /// [`wait`]: #method.wait
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use spin;
+    ///
+    /// let barrier = spin::Barrier::new(10);
+    /// ```
+    pub const fn new(n: usize) -> Self {
+        Self {
+            lock: Mutex::new(BarrierState {
+                count: 0,
+                generation_id: 0,
+            }),
+            num_threads: n,
         }
     }
 }
@@ -187,7 +187,7 @@ mod tests {
     use std::sync::Arc;
     use std::thread;
 
-    use super::Barrier;
+    type Barrier = super::Barrier;
 
     fn use_barrier(n: usize, barrier: Arc<Barrier>) {
         let (tx, rx) = channel();

--- a/src/barrier.rs
+++ b/src/barrier.rs
@@ -1,20 +1,7 @@
 //! Synchronization primitive allowing multiple threads to synchronize the
 //! beginning of some computation.
-//!
-//! Implementation adopted the 'Barrier' type of the standard library. See:
-//! https://doc.rust-lang.org/std/sync/struct.Barrier.html
-//!
-//! Copyright 2014 The Rust Project Developers. See the COPYRIGHT
-//! file at the top-level directory of this distribution and at
-//! http://rust-lang.org/COPYRIGHT.
-//!
-//! Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-//! http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-//! <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
-//! option. This file may not be copied, modified, or distributed
-//! except according to those terms.
 
-use crate::{Mutex, RelaxStrategy, Spin};
+use crate::{mutex::Mutex, RelaxStrategy, Spin};
 
 /// A primitive that synchronizes the execution of multiple threads.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,10 @@
 //!
 //! - Guard leaking
 //!
+//! - Ticket locks
+//!
+//! - Different strategies for dealing with contention
+//!
 //! # Relationship with `std::sync`
 //!
 //! While `spin` is not a drop-in replacement for `std::sync` (and
@@ -63,34 +67,78 @@ pub mod once;
 pub mod rw_lock;
 pub mod relax;
 
-pub use barrier::Barrier;
-pub use lazy::Lazy;
-pub use mutex::{Mutex, MutexGuard};
-pub use once::Once;
-pub use rw_lock::{RwLock, RwLockReadGuard, RwLockWriteGuard, RwLockUpgradableGuard};
+pub use mutex::MutexGuard;
+pub use rw_lock::RwLockReadGuard;
 pub use relax::{Spin, RelaxStrategy};
 #[cfg(feature = "std")]
 pub use relax::Yield;
 
+// Avoid confusing inference errors by aliasing away the relax strategy parameter. Users that need to use a different
+// relax strategy can do so by accessing the types through their fully-qualified path. This is a little bit horrible
+// but sadly adding a default type parameter is *still* a breaking change in Rust (for understandable reasons).
+
+/// A primitive that synchronizes the execution of multiple threads. See [`barrier::Barrier`] for documentation.
+///
+/// A note for advanced users: this alias exists to avoid subtle type inference errors due to the default relax
+/// strategy type parameter. If you need a non-default relax strategy, use the fully-qualified path.
+pub type Barrier = crate::barrier::Barrier;
+
+/// A value which is initialized on the first access. See [`lazy::Lazy`] for documentation.
+///
+/// A note for advanced users: this alias exists to avoid subtle type inference errors due to the default relax
+/// strategy type parameter. If you need a non-default relax strategy, use the fully-qualified path.
+pub type Lazy<T, F = fn() -> T> = crate::lazy::Lazy<T, F>;
+
+/// A primitive that synchronizes the execution of multiple threads. See [`mutex::Mutex`] for documentation.
+///
+/// A note for advanced users: this alias exists to avoid subtle type inference errors due to the default relax
+/// strategy type parameter. If you need a non-default relax strategy, use the fully-qualified path.
+pub type Mutex<T> = crate::mutex::Mutex<T>;
+
+/// A primitive that provides lazy one-time initialization. See [`once::Once`] for documentation.
+///
+/// A note for advanced users: this alias exists to avoid subtle type inference errors due to the default relax
+/// strategy type parameter. If you need a non-default relax strategy, use the fully-qualified path.
+pub type Once<T> = crate::once::Once<T>;
+
+/// A lock that provides data access to either one writer or many readers. See [`rw_lock::RwLock`] for documentation.
+///
+/// A note for advanced users: this alias exists to avoid subtle type inference errors due to the default relax
+/// strategy type parameter. If you need a non-default relax strategy, use the fully-qualified path.
+pub type RwLock<T> = crate::rw_lock::RwLock<T>;
+
+/// A guard that provides immutable data access but can be upgraded to [`RwLockWriteGuard`]. See
+/// [`rw_lock::RwLockUpgradableGuard`] for documentation.
+///
+/// A note for advanced users: this alias exists to avoid subtle type inference errors due to the default relax
+/// strategy type parameter. If you need a non-default relax strategy, use the fully-qualified path.
+pub type RwLockUpgradableGuard<'a, T> = crate::rw_lock::RwLockUpgradableGuard<'a, T>;
+
+/// A guard that provides mutable data access. See [`rw_lock::RwLockWriteGuard`] for documentation.
+///
+/// A note for advanced users: this alias exists to avoid subtle type inference errors due to the default relax
+/// strategy type parameter. If you need a non-default relax strategy, use the fully-qualified path.
+pub type RwLockWriteGuard<'a, T> = crate::rw_lock::RwLockWriteGuard<'a, T>;
+
 /// Spin synchronisation primitives, but compatible with [`lock_api`](https://crates.io/crates/lock_api).
-#[cfg(feature = "lock_api1")]
+#[cfg(feature = "lock_api")]
 pub mod lock_api {
     /// A lock that provides mutually exclusive data access (compatible with [`lock_api`](https://crates.io/crates/lock_api)).
-    pub type Mutex<T> = lock_api::Mutex<crate::Mutex<()>, T>;
+    pub type Mutex<T> = lock_api_crate::Mutex<crate::Mutex<()>, T>;
 
     /// A guard that provides mutable data access (compatible with [`lock_api`](https://crates.io/crates/lock_api)).
-    pub type MutexGuard<'a, T> = lock_api::MutexGuard<'a, crate::Mutex<()>, T>;
+    pub type MutexGuard<'a, T> = lock_api_crate::MutexGuard<'a, crate::Mutex<()>, T>;
 
     /// A lock that provides data access to either one writer or many readers (compatible with [`lock_api`](https://crates.io/crates/lock_api)).
-    pub type RwLock<T> = lock_api::RwLock<crate::RwLock<()>, T>;
+    pub type RwLock<T> = lock_api_crate::RwLock<crate::RwLock<()>, T>;
 
     /// A guard that provides immutable data access (compatible with [`lock_api`](https://crates.io/crates/lock_api)).
-    pub type RwLockReadGuard<'a, T> = lock_api::RwLockReadGuard<'a, crate::RwLock<()>, T>;
+    pub type RwLockReadGuard<'a, T> = lock_api_crate::RwLockReadGuard<'a, crate::RwLock<()>, T>;
 
     /// A guard that provides mutable data access (compatible with [`lock_api`](https://crates.io/crates/lock_api)).
-    pub type RwLockWriteGuard<'a, T> = lock_api::RwLockWriteGuard<'a, crate::RwLock<()>, T>;
+    pub type RwLockWriteGuard<'a, T> = lock_api_crate::RwLockWriteGuard<'a, crate::RwLock<()>, T>;
 
     /// A guard that provides immutable data access but can be upgraded to [`RwLockWriteGuard`] (compatible with [`lock_api`](https://crates.io/crates/lock_api)).
     pub type RwLockUpgradableReadGuard<'a, T> =
-        lock_api::RwLockUpgradableReadGuard<'a, crate::RwLock<()>, T>;
+        lock_api_crate::RwLockUpgradableReadGuard<'a, crate::RwLock<()>, T>;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![deny(missing_docs)]
 
 //! This crate provides [spin-based](https://en.wikipedia.org/wiki/Spinlock) versions of the
@@ -55,23 +56,21 @@
 #[cfg(any(test, feature = "std"))]
 extern crate core;
 
-// Choose a different relaxation strategy based on whether `std` is available or not.
-#[cfg(not(feature = "std"))]
-use core::sync::atomic::spin_loop_hint as relax;
-#[cfg(feature = "std")]
-use std::thread::yield_now as relax;
-
 pub mod barrier;
 pub mod lazy;
 pub mod mutex;
 pub mod once;
 pub mod rw_lock;
+pub mod relax;
 
 pub use barrier::Barrier;
 pub use lazy::Lazy;
 pub use mutex::{Mutex, MutexGuard};
 pub use once::Once;
 pub use rw_lock::{RwLock, RwLockReadGuard, RwLockWriteGuard, RwLockUpgradableGuard};
+pub use relax::{Spin, RelaxStrategy};
+#[cfg(feature = "std")]
+pub use relax::Yield;
 
 /// Spin synchronisation primitives, but compatible with [`lock_api`](https://crates.io/crates/lock_api).
 #[cfg(feature = "lock_api1")]

--- a/src/mutex.rs
+++ b/src/mutex.rs
@@ -4,13 +4,14 @@
 //! If it's enabled, [`TicketMutex`] and [`TicketMutexGuard`] will be re-exported as [`Mutex`]
 //! and [`MutexGuard`], otherwise the [`SpinMutex`] and guard will be re-exported.
 //!
-//! `ticket_mutex` is enabled by default.
+//! `ticket_mutex` is disabled by default.
 //!
 //! [`Mutex`]: ../struct.Mutex.html
 //! [`MutexGuard`]: ../struct.MutexGuard.html
 //! [`TicketMutex`]: ./struct.TicketMutex.html
 //! [`TicketMutexGuard`]: ./struct.TicketMutexGuard.html
 //! [`SpinMutex`]: ./struct.SpinMutex.html
+//! [`SpinMutexGuard`]: ./struct.SpinMutexGuard.html
 
 mod spin;
 pub use self::spin::*;
@@ -286,9 +287,9 @@ impl<'a, T: ?Sized> DerefMut for MutexGuard<'a, T> {
     }
 }
 
-#[cfg(feature = "lock_api1")]
-unsafe impl<R: RelaxStrategy> lock_api::RawMutex for Mutex<(), R> {
-    type GuardMarker = lock_api::GuardSend;
+#[cfg(feature = "lock_api")]
+unsafe impl<R: RelaxStrategy> lock_api_crate::RawMutex for Mutex<(), R> {
+    type GuardMarker = lock_api_crate::GuardSend;
 
     const INIT: Self = Self::new(());
 

--- a/src/mutex.rs
+++ b/src/mutex.rs
@@ -22,14 +22,15 @@ use core::{
     fmt,
     ops::{Deref, DerefMut},
 };
+use crate::{RelaxStrategy, Spin};
 
 #[cfg(feature = "ticket_mutex")]
-type InnerMutex<T> = TicketMutex<T>;
+type InnerMutex<T, R> = TicketMutex<T, R>;
 #[cfg(feature = "ticket_mutex")]
 type InnerMutexGuard<'a, T> = TicketMutexGuard<'a, T>;
 
 #[cfg(not(feature = "ticket_mutex"))]
-type InnerMutex<T> = SpinMutex<T>;
+type InnerMutex<T, R> = SpinMutex<T, R>;
 #[cfg(not(feature = "ticket_mutex"))]
 type InnerMutexGuard<'a, T> = SpinMutexGuard<'a, T>;
 
@@ -83,15 +84,12 @@ type InnerMutexGuard<'a, T> = SpinMutexGuard<'a, T>;
 /// let answer = { *spin_mutex.lock() };
 /// assert_eq!(answer, thread_count);
 /// ```
-pub struct Mutex<T: ?Sized> {
-    #[cfg(feature = "ticket_mutex")]
-    inner: TicketMutex<T>,
-    #[cfg(not(feature = "ticket_mutex"))]
-    inner: SpinMutex<T>,
+pub struct Mutex<T: ?Sized, R = Spin> {
+    inner: InnerMutex<T, R>,
 }
 
-unsafe impl<T: ?Sized + Send> Sync for Mutex<T> {}
-unsafe impl<T: ?Sized + Send> Send for Mutex<T> {}
+unsafe impl<T: ?Sized + Send, R> Sync for Mutex<T, R> {}
+unsafe impl<T: ?Sized + Send, R> Send for Mutex<T, R> {}
 
 /// A generic guard that will protect some data access and
 /// uses either a ticket lock or a normal spin mutex.
@@ -101,13 +99,10 @@ unsafe impl<T: ?Sized + Send> Send for Mutex<T> {}
 /// [`TicketMutexGuard`]: ./struct.TicketMutexGuard.html
 /// [`SpinMutexGuard`]: ./struct.SpinMutexGuard.html
 pub struct MutexGuard<'a, T: 'a + ?Sized> {
-    #[cfg(feature = "ticket_mutex")]
-    inner: TicketMutexGuard<'a, T>,
-    #[cfg(not(feature = "ticket_mutex"))]
-    inner: SpinMutexGuard<'a, T>,
+    inner: InnerMutexGuard<'a, T>,
 }
 
-impl<T> Mutex<T> {
+impl<T, R> Mutex<T, R> {
     /// Creates a new [`Mutex`] wrapping the supplied data.
     ///
     /// # Example
@@ -142,18 +137,7 @@ impl<T> Mutex<T> {
     }
 }
 
-impl<T: ?Sized> Mutex<T> {
-    /// Returns `true` if the lock is currently held.
-    ///
-    /// # Safety
-    ///
-    /// This function provides no synchronization guarantees and so its result should be considered 'out of date'
-    /// the instant it is called. Do not use it for synchronization purposes. However, it may be useful as a heuristic.
-    #[inline(always)]
-    pub fn is_locked(&self) -> bool {
-        self.inner.is_locked()
-    }
-
+impl<T: ?Sized, R: RelaxStrategy> Mutex<T, R> {
     /// Locks the [`Mutex`] and returns a guard that permits access to the inner data.
     ///
     /// The returned value may be dereferenced for data access
@@ -173,6 +157,19 @@ impl<T: ?Sized> Mutex<T> {
         MutexGuard {
             inner: self.inner.lock(),
         }
+    }
+}
+
+impl<T: ?Sized, R> Mutex<T, R> {
+    /// Returns `true` if the lock is currently held.
+    ///
+    /// # Safety
+    ///
+    /// This function provides no synchronization guarantees and so its result should be considered 'out of date'
+    /// the instant it is called. Do not use it for synchronization purposes. However, it may be useful as a heuristic.
+    #[inline(always)]
+    pub fn is_locked(&self) -> bool {
+        self.inner.is_locked()
     }
 
     /// Force unlock this [`Mutex`].
@@ -227,19 +224,19 @@ impl<T: ?Sized> Mutex<T> {
     }
 }
 
-impl<T: ?Sized + fmt::Debug> fmt::Debug for Mutex<T> {
+impl<T: ?Sized + fmt::Debug, R> fmt::Debug for Mutex<T, R> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Debug::fmt(&self.inner, f)
     }
 }
 
-impl<T: ?Sized + Default> Default for Mutex<T> {
-    fn default() -> Mutex<T> {
+impl<T: ?Sized + Default, R> Default for Mutex<T, R> {
+    fn default() -> Self {
         Self::new(Default::default())
     }
 }
 
-impl<T> From<T> for Mutex<T> {
+impl<T, R> From<T> for Mutex<T, R> {
     fn from(data: T) -> Self {
         Self::new(data)
     }
@@ -290,7 +287,7 @@ impl<'a, T: ?Sized> DerefMut for MutexGuard<'a, T> {
 }
 
 #[cfg(feature = "lock_api1")]
-unsafe impl lock_api::RawMutex for Mutex<()> {
+unsafe impl<R: RelaxStrategy> lock_api::RawMutex for Mutex<(), R> {
     type GuardMarker = lock_api::GuardSend;
 
     const INIT: Self = Self::new(());

--- a/src/relax.rs
+++ b/src/relax.rs
@@ -6,10 +6,18 @@ pub trait RelaxStrategy {
     fn relax();
 }
 
-/// A strategy that involves rapidly spinning while informing the CPU that it should power down non-essential
-/// components via [`spin_loop_hint`]. Note that spinning is a 'dumb' strategy and most schedulers cannot connectly
-/// differentiate it from useful work. If you see signs that priority inversion is occurring, consider switching to
-/// [`Yield`] or, even better, not using a spinlock at all and opting for a proper mutex.
+/// A strategy that rapidly spins while informing the CPU that it should power down non-essential components via
+/// [`core::hint::spin_loop`].
+///
+/// Note that spinning is a 'dumb' strategy and most schedulers cannot correctly differentiate it from useful work,
+/// thereby misallocating even more CPU time to the spinning process. This is known as
+/// ['priority inversion'](https://matklad.github.io/2020/01/02/spinlocks-considered-harmful.html).
+///
+/// If you see signs that priority inversion is occurring, consider switching to [`Yield`] or, even better, not using a
+/// spinlock at all and opting for a proper scheduler-aware lock. Remember also that different targets, operating
+/// systems, schedulers, and even the same scheduler with different workloads will exhibit different behaviour. Just
+/// because priority inversion isn't occurring in your tests does not mean that it will not occur. Use a scheduler-
+/// aware lock if at all possible.
 pub struct Spin;
 
 impl RelaxStrategy for Spin {
@@ -19,8 +27,9 @@ impl RelaxStrategy for Spin {
     }
 }
 
-/// A strategy that yields the current time slice to the scheduler in favour of other threads or processes. This is
-/// generally used as a strategy for minimising power consumption and priority inversion on targets that have a
+/// A strategy that yields the current time slice to the scheduler in favour of other threads or processes.
+///
+/// This is generally used as a strategy for minimising power consumption and priority inversion on targets that have a
 /// standard library available. Note that such targets have scheduler-integrated concurrency primitives available, and
 /// you should generally use these instead, except in rare circumstances.
 #[cfg(feature = "std")]
@@ -32,4 +41,16 @@ impl RelaxStrategy for Yield {
     fn relax() {
         std::thread::yield_now();
     }
+}
+
+/// A strategy that rapidly spins, without telling the CPU to do any powering down.
+///
+/// You almost certainly do not want to use this. Use [`Spin`] instead. It exists for completeness and for targets
+/// that, for some reason, miscompile or do not support spin hint intrinsics despite attempting to generate code for
+/// them (i.e: this is a workaround for possible compiler bugs).
+pub struct Loop;
+
+impl RelaxStrategy for Loop {
+    #[inline(always)]
+    fn relax() {}
 }

--- a/src/relax.rs
+++ b/src/relax.rs
@@ -1,0 +1,35 @@
+//! Strategies that determine the behaviour of locks when encountering contention.
+
+/// A trait implemented by spinning relax strategies.
+pub trait RelaxStrategy {
+    /// Perform the relaxing operation during a period of contention.
+    fn relax();
+}
+
+/// A strategy that involves rapidly spinning while informing the CPU that it should power down non-essential
+/// components via [`spin_loop_hint`]. Note that spinning is a 'dumb' strategy and most schedulers cannot connectly
+/// differentiate it from useful work. If you see signs that priority inversion is occurring, consider switching to
+/// [`Yield`] or, even better, not using a spinlock at all and opting for a proper mutex.
+pub struct Spin;
+
+impl RelaxStrategy for Spin {
+    #[inline(always)]
+    fn relax() {
+        core::hint::spin_loop();
+    }
+}
+
+/// A strategy that yields the current time slice to the scheduler in favour of other threads or processes. This is
+/// generally used as a strategy for minimising power consumption and priority inversion on targets that have a
+/// standard library available. Note that such targets have scheduler-integrated concurrency primitives available, and
+/// you should generally use these instead, except in rare circumstances.
+#[cfg(feature = "std")]
+pub struct Yield;
+
+#[cfg(feature = "std")]
+impl RelaxStrategy for Yield {
+    #[inline(always)]
+    fn relax() {
+        std::thread::yield_now();
+    }
+}

--- a/src/rw_lock.rs
+++ b/src/rw_lock.rs
@@ -4,9 +4,11 @@ use core::{
     cell::UnsafeCell,
     ops::{Deref, DerefMut},
     sync::atomic::{AtomicUsize, Ordering},
+    marker::PhantomData,
     fmt,
     mem,
 };
+use crate::{RelaxStrategy, Spin};
 
 /// A lock that provides data access to either one writer or many readers.
 ///
@@ -61,7 +63,8 @@ use core::{
 ///     assert_eq!(*w, 6);
 /// } // write lock is dropped here
 /// ```
-pub struct RwLock<T: ?Sized> {
+pub struct RwLock<T: ?Sized, R = Spin> {
+    phantom: PhantomData<R>,
     lock: AtomicUsize,
     data: UnsafeCell<T>,
 }
@@ -75,15 +78,16 @@ const WRITER: usize = 1;
 /// When the guard falls out of scope it will decrement the read count,
 /// potentially releasing the lock.
 pub struct RwLockReadGuard<'a, T: 'a + ?Sized> {
-    inner: &'a RwLock<T>,
+    lock: &'a AtomicUsize,
     data: &'a T,
 }
 
 /// A guard that provides mutable data access.
 ///
 /// When the guard falls out of scope it will release the lock.
-pub struct RwLockWriteGuard<'a, T: 'a + ?Sized> {
-    inner: &'a RwLock<T>,
+pub struct RwLockWriteGuard<'a, T: 'a + ?Sized, R> {
+    phantom: PhantomData<R>,
+    inner: &'a RwLock<T, R>,
     data: &'a mut T,
 }
 
@@ -95,16 +99,17 @@ pub struct RwLockWriteGuard<'a, T: 'a + ?Sized> {
 /// when the lock is acquired.
 ///
 /// When the guard falls out of scope it will release the lock.
-pub struct RwLockUpgradableGuard<'a, T: 'a + ?Sized> {
-    inner: &'a RwLock<T>,
+pub struct RwLockUpgradableGuard<'a, T: 'a + ?Sized, R> {
+    phantom: PhantomData<R>,
+    inner: &'a RwLock<T, R>,
     data: &'a T,
 }
 
 // Same unsafe impls as `std::sync::RwLock`
-unsafe impl<T: ?Sized + Send> Send for RwLock<T> {}
-unsafe impl<T: ?Sized + Send + Sync> Sync for RwLock<T> {}
+unsafe impl<T: ?Sized + Send, R> Send for RwLock<T, R> {}
+unsafe impl<T: ?Sized + Send + Sync, R> Sync for RwLock<T, R> {}
 
-impl<T> RwLock<T> {
+impl<T, R> RwLock<T, R> {
     /// Creates a new spinlock wrapping the supplied data.
     ///
     /// May be used statically:
@@ -121,10 +126,11 @@ impl<T> RwLock<T> {
     /// }
     /// ```
     #[inline]
-    pub const fn new(user_data: T) -> RwLock<T> {
+    pub const fn new(data: T) -> Self {
         RwLock {
+            phantom: PhantomData,
             lock: AtomicUsize::new(0),
-            data: UnsafeCell::new(user_data),
+            data: UnsafeCell::new(data),
         }
     }
 
@@ -138,7 +144,7 @@ impl<T> RwLock<T> {
     }
 }
 
-impl<T: ?Sized> RwLock<T> {
+impl<T: ?Sized, R: RelaxStrategy> RwLock<T, R> {
     /// Locks this rwlock with shared read access, blocking the current thread
     /// until it can be acquired.
     ///
@@ -165,11 +171,53 @@ impl<T: ?Sized> RwLock<T> {
         loop {
             match self.try_read() {
                 Some(guard) => return guard,
-                None => crate::relax(),
+                None => R::relax(),
             }
         }
     }
 
+    /// Lock this rwlock with exclusive write access, blocking the current
+    /// thread until it can be acquired.
+    ///
+    /// This function will not return while other writers or other readers
+    /// currently have access to the lock.
+    ///
+    /// Returns an RAII guard which will drop the write access of this rwlock
+    /// when dropped.
+    ///
+    /// ```
+    /// let mylock = spin::RwLock::new(0);
+    /// {
+    ///     let mut data = mylock.write();
+    ///     // The lock is now locked and the data can be written
+    ///     *data += 1;
+    ///     // The lock is dropped
+    /// }
+    /// ```
+    #[inline]
+    pub fn write(&self) -> RwLockWriteGuard<T, R> {
+        loop {
+            match self.try_write_internal(false) {
+                Some(guard) => return guard,
+                None => R::relax(),
+            }
+        }
+    }
+
+    /// Obtain a readable lock guard that can later be upgraded to a writable lock guard.
+    /// Upgrades can be done through the [`RwLockUpgradableGuard::upgrade`](RwLockUpgradableGuard::upgrade) method.
+    #[inline]
+    pub fn upgradeable_read(&self) -> RwLockUpgradableGuard<T, R> {
+        loop {
+            match self.try_upgradeable_read() {
+                Some(guard) => return guard,
+                None => R::relax(),
+            }
+        }
+    }
+}
+
+impl<T: ?Sized, R> RwLock<T, R> {
     /// Attempt to acquire this lock with shared read access.
     ///
     /// This function will never block and will return immediately if `read`
@@ -204,7 +252,7 @@ impl<T: ?Sized> RwLock<T> {
             None
         } else {
             Some(RwLockReadGuard {
-                inner: self,
+                lock: &self.lock,
                 data: unsafe { &*self.data.get() },
             })
         }
@@ -262,7 +310,7 @@ impl<T: ?Sized> RwLock<T> {
     }
 
     #[inline(always)]
-    fn try_write_internal(&self, strong: bool) -> Option<RwLockWriteGuard<T>> {
+    fn try_write_internal(&self, strong: bool) -> Option<RwLockWriteGuard<T, R>> {
         if compare_exchange(
             &self.lock,
             0,
@@ -274,39 +322,12 @@ impl<T: ?Sized> RwLock<T> {
         .is_ok()
         {
             Some(RwLockWriteGuard {
+                phantom: PhantomData,
                 inner: self,
                 data: unsafe { &mut *self.data.get() },
             })
         } else {
             None
-        }
-    }
-
-    /// Lock this rwlock with exclusive write access, blocking the current
-    /// thread until it can be acquired.
-    ///
-    /// This function will not return while other writers or other readers
-    /// currently have access to the lock.
-    ///
-    /// Returns an RAII guard which will drop the write access of this rwlock
-    /// when dropped.
-    ///
-    /// ```
-    /// let mylock = spin::RwLock::new(0);
-    /// {
-    ///     let mut data = mylock.write();
-    ///     // The lock is now locked and the data can be written
-    ///     *data += 1;
-    ///     // The lock is dropped
-    /// }
-    /// ```
-    #[inline]
-    pub fn write(&self) -> RwLockWriteGuard<T> {
-        loop {
-            match self.try_write_internal(false) {
-                Some(guard) => return guard,
-                None => crate::relax(),
-            }
         }
     }
 
@@ -330,27 +351,16 @@ impl<T: ?Sized> RwLock<T> {
     /// }
     /// ```
     #[inline]
-    pub fn try_write(&self) -> Option<RwLockWriteGuard<T>> {
+    pub fn try_write(&self) -> Option<RwLockWriteGuard<T, R>> {
         self.try_write_internal(true)
-    }
-
-    /// Obtain a readable lock guard that can later be upgraded to a writable lock guard.
-    /// Upgrades can be done through the [`RwLockUpgradableGuard::upgrade`](RwLockUpgradableGuard::upgrade) method.
-    #[inline]
-    pub fn upgradeable_read(&self) -> RwLockUpgradableGuard<T> {
-        loop {
-            match self.try_upgradeable_read() {
-                Some(guard) => return guard,
-                None => crate::relax(),
-            }
-        }
     }
 
     /// Tries to obtain an upgradeable lock guard.
     #[inline]
-    pub fn try_upgradeable_read(&self) -> Option<RwLockUpgradableGuard<T>> {
+    pub fn try_upgradeable_read(&self) -> Option<RwLockUpgradableGuard<T, R>> {
         if self.lock.fetch_or(UPGRADED, Ordering::Acquire) & (WRITER | UPGRADED) == 0 {
             Some(RwLockUpgradableGuard {
+                phantom: PhantomData,
                 inner: self,
                 data: unsafe { &*self.data.get() },
             })
@@ -380,7 +390,7 @@ impl<T: ?Sized> RwLock<T> {
     }
 }
 
-impl<T: ?Sized + fmt::Debug> fmt::Debug for RwLock<T> {
+impl<T: ?Sized + fmt::Debug, R> fmt::Debug for RwLock<T, R> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self.try_read() {
             Some(guard) => write!(f, "RwLock {{ data: ")
@@ -391,13 +401,13 @@ impl<T: ?Sized + fmt::Debug> fmt::Debug for RwLock<T> {
     }
 }
 
-impl<T: ?Sized + Default> Default for RwLock<T> {
-    fn default() -> RwLock<T> {
+impl<T: ?Sized + Default, R> Default for RwLock<T, R> {
+    fn default() -> Self {
         Self::new(Default::default())
     }
 }
 
-impl<T> From<T> for RwLock<T> {
+impl<T, R> From<T> for RwLock<T, R> {
     fn from(data: T) -> Self {
         Self::new(data)
     }
@@ -434,9 +444,31 @@ impl<'rwlock, T: ?Sized + fmt::Display> fmt::Display for RwLockReadGuard<'rwlock
     }
 }
 
-impl<'rwlock, T: ?Sized> RwLockUpgradableGuard<'rwlock, T> {
+impl<'rwlock, T: ?Sized, R: RelaxStrategy> RwLockUpgradableGuard<'rwlock, T, R> {
+    /// Upgrades an upgradeable lock guard to a writable lock guard.
+    ///
+    /// ```
+    /// let mylock = spin::RwLock::new(0);
+    ///
+    /// let upgradeable = mylock.upgradeable_read(); // Readable, but not yet writable
+    /// let writable = upgradeable.upgrade();
+    /// ```
+    #[inline]
+    pub fn upgrade(mut self) -> RwLockWriteGuard<'rwlock, T, R> {
+        loop {
+            self = match self.try_upgrade_internal(false) {
+                Ok(guard) => return guard,
+                Err(e) => e,
+            };
+
+            R::relax();
+        }
+    }
+}
+
+impl<'rwlock, T: ?Sized, R> RwLockUpgradableGuard<'rwlock, T, R> {
     #[inline(always)]
-    fn try_upgrade_internal(self, strong: bool) -> Result<RwLockWriteGuard<'rwlock, T>, Self> {
+    fn try_upgrade_internal(self, strong: bool) -> Result<RwLockWriteGuard<'rwlock, T, R>, Self> {
         if compare_exchange(
             &self.inner.lock,
             UPGRADED,
@@ -454,31 +486,12 @@ impl<'rwlock, T: ?Sized> RwLockUpgradableGuard<'rwlock, T> {
 
             // Upgrade successful
             Ok(RwLockWriteGuard {
+                phantom: PhantomData,
                 inner,
                 data: unsafe { &mut *inner.data.get() },
             })
         } else {
             Err(self)
-        }
-    }
-
-    /// Upgrades an upgradeable lock guard to a writable lock guard.
-    ///
-    /// ```
-    /// let mylock = spin::RwLock::new(0);
-    ///
-    /// let upgradeable = mylock.upgradeable_read(); // Readable, but not yet writable
-    /// let writable = upgradeable.upgrade();
-    /// ```
-    #[inline]
-    pub fn upgrade(mut self) -> RwLockWriteGuard<'rwlock, T> {
-        loop {
-            self = match self.try_upgrade_internal(false) {
-                Ok(guard) => return guard,
-                Err(e) => e,
-            };
-
-            crate::relax();
         }
     }
 
@@ -494,7 +507,7 @@ impl<'rwlock, T: ?Sized> RwLockUpgradableGuard<'rwlock, T> {
     /// };
     /// ```
     #[inline]
-    pub fn try_upgrade(self) -> Result<RwLockWriteGuard<'rwlock, T>, Self> {
+    pub fn try_upgrade(self) -> Result<RwLockWriteGuard<'rwlock, T, R>, Self> {
         self.try_upgrade_internal(true)
     }
 
@@ -522,7 +535,7 @@ impl<'rwlock, T: ?Sized> RwLockUpgradableGuard<'rwlock, T> {
         mem::drop(self);
 
         RwLockReadGuard {
-            inner,
+            lock: &inner.lock,
             data: unsafe { &*inner.data.get() },
         }
     }
@@ -545,19 +558,19 @@ impl<'rwlock, T: ?Sized> RwLockUpgradableGuard<'rwlock, T> {
     }
 }
 
-impl<'rwlock, T: ?Sized + fmt::Debug> fmt::Debug for RwLockUpgradableGuard<'rwlock, T> {
+impl<'rwlock, T: ?Sized + fmt::Debug, R> fmt::Debug for RwLockUpgradableGuard<'rwlock, T, R> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Debug::fmt(&**self, f)
     }
 }
 
-impl<'rwlock, T: ?Sized + fmt::Display> fmt::Display for RwLockUpgradableGuard<'rwlock, T> {
+impl<'rwlock, T: ?Sized + fmt::Display, R> fmt::Display for RwLockUpgradableGuard<'rwlock, T, R> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Display::fmt(&**self, f)
     }
 }
 
-impl<'rwlock, T: ?Sized> RwLockWriteGuard<'rwlock, T> {
+impl<'rwlock, T: ?Sized, R> RwLockWriteGuard<'rwlock, T, R> {
     /// Downgrades the writable lock guard to a readable, shared lock guard. Cannot fail and is guaranteed not to spin.
     ///
     /// ```
@@ -581,7 +594,7 @@ impl<'rwlock, T: ?Sized> RwLockWriteGuard<'rwlock, T> {
         mem::drop(self);
 
         RwLockReadGuard {
-            inner,
+            lock: &inner.lock,
             data: unsafe { &*inner.data.get() },
         }
     }
@@ -598,7 +611,7 @@ impl<'rwlock, T: ?Sized> RwLockWriteGuard<'rwlock, T> {
     /// assert_eq!(*readable, 1);
     /// ```
     #[inline]
-    pub fn downgrade_to_upgradeable(self) -> RwLockUpgradableGuard<'rwlock, T> {
+    pub fn downgrade_to_upgradeable(self) -> RwLockUpgradableGuard<'rwlock, T, R> {
         debug_assert_eq!(self.inner.lock.load(Ordering::Acquire) & (WRITER | UPGRADED), WRITER);
 
         // Reserve the read guard for ourselves
@@ -610,6 +623,7 @@ impl<'rwlock, T: ?Sized> RwLockWriteGuard<'rwlock, T> {
         mem::forget(self);
 
         RwLockUpgradableGuard {
+            phantom: PhantomData,
             inner,
             data: unsafe { &*inner.data.get() },
         }
@@ -635,13 +649,13 @@ impl<'rwlock, T: ?Sized> RwLockWriteGuard<'rwlock, T> {
     }
 }
 
-impl<'rwlock, T: ?Sized + fmt::Debug> fmt::Debug for RwLockWriteGuard<'rwlock, T> {
+impl<'rwlock, T: ?Sized + fmt::Debug, R> fmt::Debug for RwLockWriteGuard<'rwlock, T, R> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Debug::fmt(&**self, f)
     }
 }
 
-impl<'rwlock, T: ?Sized + fmt::Display> fmt::Display for RwLockWriteGuard<'rwlock, T> {
+impl<'rwlock, T: ?Sized + fmt::Display, R> fmt::Display for RwLockWriteGuard<'rwlock, T, R> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Display::fmt(&**self, f)
     }
@@ -655,7 +669,7 @@ impl<'rwlock, T: ?Sized> Deref for RwLockReadGuard<'rwlock, T> {
     }
 }
 
-impl<'rwlock, T: ?Sized> Deref for RwLockUpgradableGuard<'rwlock, T> {
+impl<'rwlock, T: ?Sized, R> Deref for RwLockUpgradableGuard<'rwlock, T, R> {
     type Target = T;
 
     fn deref(&self) -> &T {
@@ -663,7 +677,7 @@ impl<'rwlock, T: ?Sized> Deref for RwLockUpgradableGuard<'rwlock, T> {
     }
 }
 
-impl<'rwlock, T: ?Sized> Deref for RwLockWriteGuard<'rwlock, T> {
+impl<'rwlock, T: ?Sized, R> Deref for RwLockWriteGuard<'rwlock, T, R> {
     type Target = T;
 
     fn deref(&self) -> &T {
@@ -671,7 +685,7 @@ impl<'rwlock, T: ?Sized> Deref for RwLockWriteGuard<'rwlock, T> {
     }
 }
 
-impl<'rwlock, T: ?Sized> DerefMut for RwLockWriteGuard<'rwlock, T> {
+impl<'rwlock, T: ?Sized, R> DerefMut for RwLockWriteGuard<'rwlock, T, R> {
     fn deref_mut(&mut self) -> &mut T {
         self.data
     }
@@ -679,12 +693,12 @@ impl<'rwlock, T: ?Sized> DerefMut for RwLockWriteGuard<'rwlock, T> {
 
 impl<'rwlock, T: ?Sized> Drop for RwLockReadGuard<'rwlock, T> {
     fn drop(&mut self) {
-        debug_assert!(self.inner.lock.load(Ordering::Relaxed) & !(WRITER | UPGRADED) > 0);
-        self.inner.lock.fetch_sub(READER, Ordering::Release);
+        debug_assert!(self.lock.load(Ordering::Relaxed) & !(WRITER | UPGRADED) > 0);
+        self.lock.fetch_sub(READER, Ordering::Release);
     }
 }
 
-impl<'rwlock, T: ?Sized> Drop for RwLockUpgradableGuard<'rwlock, T> {
+impl<'rwlock, T: ?Sized, R> Drop for RwLockUpgradableGuard<'rwlock, T, R> {
     fn drop(&mut self) {
         debug_assert_eq!(
             self.inner.lock.load(Ordering::Relaxed) & (WRITER | UPGRADED),
@@ -694,7 +708,7 @@ impl<'rwlock, T: ?Sized> Drop for RwLockUpgradableGuard<'rwlock, T> {
     }
 }
 
-impl<'rwlock, T: ?Sized> Drop for RwLockWriteGuard<'rwlock, T> {
+impl<'rwlock, T: ?Sized, R> Drop for RwLockWriteGuard<'rwlock, T, R> {
     fn drop(&mut self) {
         debug_assert_eq!(self.inner.lock.load(Ordering::Relaxed) & WRITER, WRITER);
 
@@ -761,7 +775,7 @@ unsafe impl lock_api::RawRwLock for RwLock<()> {
     #[inline(always)]
     unsafe fn unlock_shared(&self) {
         drop(RwLockReadGuard {
-            inner: self,
+            lock: &self.lock,
             data: &(),
         });
     }
@@ -852,7 +866,7 @@ mod tests {
     use std::sync::Arc;
     use std::thread;
 
-    use super::*;
+    type RwLock<T> = super::RwLock<T>;
 
     #[derive(Eq, PartialEq, Debug)]
     struct NonCopy(i32);
@@ -987,7 +1001,7 @@ mod tests {
     #[test]
     fn test_rw_try_read() {
         let m = RwLock::new(0);
-        mem::forget(m.write());
+        ::std::mem::forget(m.write());
         assert!(m.try_read().is_none());
     }
 


### PR DESCRIPTION
This currently has issues due to https://github.com/rust-lang/rust/issues/50822. Event fairly mundane examples will not compile because the compiler does not infer the default parameter without a type annotation, and type namespace paths are not type annotations.

The following example...

```rust
let mylock = spin::Mutex::new(0);
```

...fails with...

```
error[E0282]: type annotations needed for `spin::Mutex<i32, R>`
 --> test.rs:1:14
  |
1 | let mylock = spin::Mutex::new(0);
  |     ------   ^^^^^^^^^^^^^^^^^ cannot infer type for type parameter `R`
  |     |
  |     consider giving `mylock` the explicit type `spin::Mutex<i32, R>`, where the type parameter `R` is specified

error: aborting due to previous error
```

I'm undecided about what approach to use to solve this. Perhaps we should use a series of type aliases within the crate to specify a default `Spin` relax strategy, thereby avoiding major breakage for most users but allowing advanced users to opt-in, albeit through a more unconventional way of accessing the types?