### PR TITLE
Allow getting the inner pointer directly for locks.

### DIFF
--- a/src/lazy.rs
+++ b/src/lazy.rs
@@ -63,6 +63,14 @@ impl<T, F, R> Lazy<T, F, R> {
     pub const fn new(f: F) -> Self {
         Self { cell: Once::new(), init: Cell::new(Some(f)) }
     }
+    /// Retrieves a mutable pointer to the inner data.
+    ///
+    /// This is especially useful when interfacing with low level code or FFI where the caller
+    /// explicitly knows that it has exclusive access to the inner data. Note that reading from
+    /// this pointer is UB until initialized or directly written to.
+    pub fn as_mut_ptr(&self) -> *mut T {
+        self.cell.as_mut_ptr()
+    }
 }
 
 impl<T, F: FnOnce() -> T, R: RelaxStrategy> Lazy<T, F, R> {

--- a/src/mutex/spin.rs
+++ b/src/mutex/spin.rs
@@ -117,6 +117,32 @@ impl<T, R> SpinMutex<T, R> {
         let SpinMutex { data, .. } = self;
         data.into_inner()
     }
+
+    /// Returns a mutable pointer to the underying data.
+    ///
+    /// This is mostly meant to be used for applications which require manual unlocking, but where
+    /// storing both the lock and the pointer to the inner data gets inefficient.
+    ///
+    /// # Example
+    /// ```
+    /// let lock = spin::mutex::SpinMutex::<_>::new(42);
+    ///
+    /// unsafe {
+    ///     core::mem::forget(lock.lock());
+    ///     
+    ///     assert_eq!(lock.as_mut_ptr().read(), 42);
+    ///     lock.as_mut_ptr().write(58);
+    ///
+    ///     lock.force_unlock();
+    /// }
+    ///
+    /// assert_eq!(*lock.lock(), 58);
+    ///
+    /// ```
+    #[inline(always)]
+    pub fn as_mut_ptr(&self) -> *mut T {
+        self.data.get()
+    }
 }
 
 impl<T: ?Sized, R: RelaxStrategy> SpinMutex<T, R> {

--- a/src/mutex/spin.rs
+++ b/src/mutex/spin.rs
@@ -118,7 +118,7 @@ impl<T, R> SpinMutex<T, R> {
         data.into_inner()
     }
 
-    /// Returns a mutable pointer to the underying data.
+    /// Returns a mutable pointer to the underlying data.
     ///
     /// This is mostly meant to be used for applications which require manual unlocking, but where
     /// storing both the lock and the pointer to the inner data gets inefficient.

--- a/src/mutex/ticket.rs
+++ b/src/mutex/ticket.rs
@@ -125,6 +125,31 @@ impl<T, R> TicketMutex<T, R> {
     pub fn into_inner(self) -> T {
         self.data.into_inner()
     }
+    /// Returns a mutable pointer to the underying data.
+    ///
+    /// This is mostly meant to be used for applications which require manual unlocking, but where
+    /// storing both the lock and the pointer to the inner data gets inefficient.
+    ///
+    /// # Example
+    /// ```
+    /// let lock = spin::mutex::SpinMutex::<_>::new(42);
+    ///
+    /// unsafe {
+    ///     core::mem::forget(lock.lock());
+    ///     
+    ///     assert_eq!(lock.as_mut_ptr().read(), 42);
+    ///     lock.as_mut_ptr().write(58);
+    ///
+    ///     lock.force_unlock();
+    /// }
+    ///
+    /// assert_eq!(*lock.lock(), 58);
+    ///
+    /// ```
+    #[inline(always)]
+    pub fn as_mut_ptr(&self) -> *mut T {
+        self.data.get()
+    }
 }
 
 impl<T: ?Sized + fmt::Debug, R> fmt::Debug for TicketMutex<T, R> {

--- a/src/once.rs
+++ b/src/once.rs
@@ -194,6 +194,17 @@ impl<T, R> Once<T, R> {
         }
     }
 
+    /// Retrieve a pointer to the inner data.
+    ///
+    /// While this method itself is safe, accessing the pointer before the [`Once`] has been
+    /// initialized is UB, unless this method has already been written to from a pointer coming
+    /// from this method.
+    pub fn as_mut_ptr(&self) -> *mut T {
+        // SAFETY:
+        // * MaybeUninit<T> always has exactly the same layout as T
+        self.data.get().cast::<T>()
+    }
+
     /// Get a reference to the initialized instance. Must only be called once COMPLETE.
     unsafe fn force_get(&self) -> &T {
         // SAFETY:

--- a/src/rwlock.rs
+++ b/src/rwlock.rs
@@ -146,8 +146,8 @@ impl<T, R> RwLock<T, R> {
     /// This is mostly meant to be used for applications which require manual unlocking, but where
     /// storing both the lock and the pointer to the inner data gets inefficient.
     ///
-    /// While this is safe, accessing the data is undefined behavior unless the current thread has
-    /// acquired a write lock.
+    /// While this is safe, writing to the data is undefined behavior unless the current thread has
+    /// acquired a write lock, and reading requires either a read or write lock.
     ///
     /// # Example
     /// ```


### PR DESCRIPTION
Even if it is possible to store a both reference to the lock and the pointer to the inner data, from a leaked guard, in some wrapped struct, this requires storing two words, which is suboptimal, when the inner data is literally just a field inside the lock struct. And while it is possible to use `lock_api`'s guard types with spin as the underlying lock, where `lock_api` has `data_ptr`, it would be really useful if `spin` could also directly do this.