### PR TITLE
Use Acquire-Release rather than SeqCst in Once.

### DIFF
--- a/src/once.rs
+++ b/src/once.rs
@@ -109,9 +109,13 @@ impl<T, R: RelaxStrategy> Once<T, R> {
                 // must always be at least as strong as the failure ordering, so we choose Acquire
                 // here anyway.
                 Ordering::Acquire,
-                // SAFETY: Failure ordering: While we have already loaded the status, we know
-                // that if some other thread would have initialized this in between, then we
-                // also want those changes as well, to become visible for us.
+                // SAFETY: Failure ordering: While we have already loaded the status initially, we
+                // know that if some other thread would have fully initialized this in between,
+                // then there will be new not-yet-synchronized accesses done during that
+                // initialization that would not have been synchronized by the earlier load. Thus
+                // we use Acquire to ensure when we later call force_get() in the last match
+                // statement, if the status was changed to COMPLETE, that those accesses will become
+                // visible to us.
                 Ordering::Acquire,
             ) {
                 Ok(_must_be_state_incomplete) => {

--- a/src/once.rs
+++ b/src/once.rs
@@ -169,6 +169,11 @@ impl<T, R: RelaxStrategy> Once<T, R> {
                     }
                 }),
 
+            // SAFETY: The only invariant possible in addition to the aforementioned ones at the
+            // moment, is INCOMPLETE. However, the only way for this match statement to be
+            // reached, is if we lost the CAS (otherwise we would have returned early), in
+            // which case we know for a fact that the state cannot be changed back to INCOMPLETE as
+            // `Once`s are monotonic.
             _ => unsafe { unreachable() },
         }
 

--- a/src/once.rs
+++ b/src/once.rs
@@ -333,7 +333,8 @@ impl<T, R> Once<T, R> {
     /// Checks whether the value has been initialized.
     ///
     /// This is done using [`Acquire`](core::sync::atomic::Ordering::Acquire) ordering, and
-    /// therefore it is safe to access the value directly via [`as_mut_ptr`] if this returns true.
+    /// therefore it is safe to access the value directly via
+    /// [`get_unchecked`](Self::get_unchecked) if this returns true.
     pub fn is_completed(&self) -> bool {
         // TODO: Add a similar variant for Relaxed?
         self.status.load(Ordering::Acquire) == COMPLETE


### PR DESCRIPTION
On most architectures, even strongly-ordered x86_64, `SeqCst` is slower than Acquire-Release, and in many situations not even required. This PR replaces SeqCst with Acquire-Release, just like the orderings used in `Once` from libstd.

The only thing I am unsure about, is whether `Relaxed` would suffice when indicating that there been a panic, but given the `RwLock` vulnerability related to `Relaxed` in the past, I think it's best to stick to `Release`. Panics are not supposed to be optimized anyway.