### PR TITLE
Use enums and u8 instead of usize in Once.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Improved `Once` performance by reducing the memory footprint of internal state to one byte
+
 ### Fixed
 
 - Improved performance of `Once` by relaxing ordering guarantees and removing redundant checks

--- a/src/once.rs
+++ b/src/once.rs
@@ -56,6 +56,7 @@ mod status {
     // SAFETY: This structure has an invariant, namely that the inner atomic u8 must *always* have
     // a value for which there exists a valid Status. This means that users of this API must only
     // be allowed to load and store `Status`es.
+    #[repr(transparent)]
     pub struct AtomicStatus(AtomicU8);
 
     // Four states that a Once can be in, encoded into the lower bits of `status` in


### PR DESCRIPTION
This also removes the `panicked` field from the panic unwind guard in call_once, cf. https://github.com/mvdnes/spin-rs/issues/110. Hence, the destructor will _only_ be called when unwinding after a panic, and otherwise it will become a no-op no matter how stupid the compiler may be (without optimizations, that is).

The major benefit of using enums instead of raw constants, is that we don't need to put `_ => unreachable_unchecked!()` at the end of all match statements, and therefore adding new enum variants will not silently cause UB if one would forget to add the new variants there.