### PR TITLE
Add portable_atomic feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,9 +2,9 @@
 name = "spin"
 version = "0.9.3"
 authors = [
-	"Mathijs van de Nes <git@mathijs.vd-nes.nl>",
-	"John Ericson <git@JohnEricson.me>",
-	"Joshua Barretto <joshua.s.barretto@gmail.com>",
+    "Mathijs van de Nes <git@mathijs.vd-nes.nl>",
+    "John Ericson <git@JohnEricson.me>",
+    "Joshua Barretto <joshua.s.barretto@gmail.com>",
 ]
 license = "MIT"
 repository = "https://github.com/mvdnes/spin-rs.git"
@@ -13,6 +13,7 @@ description = "Spin-based synchronization primitives"
 
 [dependencies]
 lock_api_crate = { package = "lock_api", version = "0.4", optional = true }
+portable-atomic = { version = "0.3", optional = true }
 
 [features]
 default = ["lock_api", "mutex", "spin_mutex", "rwlock", "once", "lazy", "barrier"]
@@ -46,6 +47,10 @@ lock_api = ["lock_api_crate"]
 
 # Enables std-only features such as yield-relaxing.
 std = []
+
+# Use the portable_atomic crate to support platforms without native atomic operations (Cortex-M0, ARMv4, etc.)
+# NOTE by its nature,
+portable_atomic = ["portable-atomic"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,8 +48,9 @@ lock_api = ["lock_api_crate"]
 # Enables std-only features such as yield-relaxing.
 std = []
 
-# Use the portable_atomic crate to support platforms without native atomic operations (Cortex-M0, ARMv4, etc.)
-# NOTE by its nature,
+# Use the portable_atomic crate to support platforms without native atomic operations
+# cfg 'portable_atomic_unsafe_assume_single_core' must also be set by the final binary crate.
+# This is an unsafe feature and enabling it for multicore systems is unsound.
 portable_atomic = ["portable-atomic"]
 
 [package.metadata.docs.rs]

--- a/README.md
+++ b/README.md
@@ -92,9 +92,10 @@ The crate comes with a few feature flags that you may wish to use.
 
 - `std` enables support for thread yielding instead of spinning.
 
-- `portable_atomic` enables usage of the `portable-atomic` crate 
+- `portable_atomic` enables usage of the `portable-atomic` crate
   to support platforms without native atomic operations (Cortex-M0, etc.).
-  The `portable_atomic_unsafe_assume_single_core` cfg flag must also be set by the _building_ project. 
+  The `portable_atomic_unsafe_assume_single_core` cfg flag
+  must also be set by the final binary crate.
   This can be done by adapting the following snippet to the `.cargo/config` file:
   ```
   [target.<target>]

--- a/README.md
+++ b/README.md
@@ -92,6 +92,16 @@ The crate comes with a few feature flags that you may wish to use.
 
 - `std` enables support for thread yielding instead of spinning.
 
+- `portable_atomic` enables usage of the `portable-atomic` crate 
+  to support platforms without native atomic operations (Cortex-M0, etc.).
+  The `portable_atomic_unsafe_assume_single_core` cfg flag must also be set by the _building_ project. 
+  This can be done by adapting the following snippet to the `.cargo/config` file:
+  ```
+  [target.<target>]
+  rustflags = [ "--cfg", "portable_atomic_unsafe_assume_single_core" ]
+  ```
+  Note that this feature is unsafe by nature, and enabling it for multicore systems is unsound.
+
 ## Remarks
 
 It is often desirable to have a lock shared between threads. Wrapping the lock in an

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,14 @@
 #[cfg(any(test, feature = "std"))]
 extern crate core;
 
+#[cfg(feature = "portable_atomic")]
+extern crate portable_atomic;
+
+#[cfg(feature = "portable_atomic")]
+use portable_atomic as atomic;
+#[cfg(not(feature = "portable_atomic"))]
+use core::sync::atomic;
+
 #[cfg(feature = "barrier")]
 #[cfg_attr(docsrs, doc(cfg(feature = "barrier")))]
 pub mod barrier;

--- a/src/mutex/spin.rs
+++ b/src/mutex/spin.rs
@@ -7,10 +7,12 @@ use core::{
     cell::UnsafeCell,
     fmt,
     ops::{Deref, DerefMut},
-    sync::atomic::{AtomicBool, Ordering},
     marker::PhantomData,
 };
-use crate::{RelaxStrategy, Spin};
+use crate::{
+    atomic::{AtomicBool, Ordering},
+    RelaxStrategy, Spin
+};
 
 /// A [spin lock](https://en.m.wikipedia.org/wiki/Spinlock) providing mutually exclusive access to data.
 ///

--- a/src/mutex/ticket.rs
+++ b/src/mutex/ticket.rs
@@ -9,10 +9,13 @@ use core::{
     cell::UnsafeCell,
     fmt,
     ops::{Deref, DerefMut},
-    sync::atomic::{AtomicUsize, Ordering},
     marker::PhantomData,
 };
-use crate::{RelaxStrategy, Spin};
+use crate::{
+    atomic::{AtomicUsize, Ordering},
+    RelaxStrategy, Spin
+};
+
 
 /// A spin-based [ticket lock](https://en.wikipedia.org/wiki/Ticket_lock) providing mutually exclusive access to data.
 ///

--- a/src/once.rs
+++ b/src/once.rs
@@ -3,11 +3,14 @@
 use core::{
     cell::UnsafeCell,
     mem::MaybeUninit,
-    sync::atomic::{AtomicU8, Ordering},
     marker::PhantomData,
     fmt,
 };
-use crate::{RelaxStrategy, Spin};
+use crate::{
+    atomic::{AtomicU8, Ordering},
+    RelaxStrategy, Spin
+};
+
 
 /// A primitive that provides lazy one-time initialization.
 ///

--- a/src/rwlock.rs
+++ b/src/rwlock.rs
@@ -3,12 +3,15 @@
 use core::{
     cell::UnsafeCell,
     ops::{Deref, DerefMut},
-    sync::atomic::{AtomicUsize, Ordering},
     marker::PhantomData,
     fmt,
     mem,
 };
-use crate::{RelaxStrategy, Spin};
+use crate::{
+    atomic::{AtomicUsize, Ordering},
+    RelaxStrategy, Spin
+};
+
 
 /// A lock that provides data access to either one writer or many readers.
 ///


### PR DESCRIPTION
Add optional `portable_atomic` feature to enable the `portable-atomic` crate for use of emulated atomic operations on platforms that don't have them. 

This is in response to https://github.com/mvdnes/spin-rs/issues/114. Code changes follow closely those of previously proposed `atomic-polyfill` PR https://github.com/mvdnes/spin-rs/pull/115

I've expanded a bit on the feature and its implications in the README.

Tested as working with my app (unpublished yet) - a host USB stack on Atmel SAM D21 which has a single Cortex-M0 core. 

I will gladly update this PR if any changes are deemed necessary.