### PR TITLE
Disable default features of portable-atomic, and fix docs about portable_atomic feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ std = []
 
 # Use the portable_atomic crate to support platforms without native atomic operations
 # cfg 'portable_atomic_unsafe_assume_single_core' must also be set by the final binary crate.
-# This is an unsafe feature and enabling it for multicore systems is unsound.
+# This cfg is unsafe and enabling it for multicore systems is unsound.
 portable_atomic = ["portable-atomic"]
 
 [package.metadata.docs.rs]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ description = "Spin-based synchronization primitives"
 
 [dependencies]
 lock_api_crate = { package = "lock_api", version = "0.4", optional = true }
-portable-atomic = { version = "0.3", optional = true }
+portable-atomic = { version = "0.3", optional = true, default-features = false }
 
 [features]
 default = ["lock_api", "mutex", "spin_mutex", "rwlock", "once", "lazy", "barrier"]

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ The crate comes with a few feature flags that you may wish to use.
   [target.<target>]
   rustflags = [ "--cfg", "portable_atomic_unsafe_assume_single_core" ]
   ```
-  Note that this feature is unsafe by nature, and enabling it for multicore systems is unsound.
+  Note that this cfg is unsafe by nature, and enabling it for multicore systems is unsound.
 
 ## Remarks
 


### PR DESCRIPTION
- The default feature of portable-atomic is mainly for users who use atomics larger than the pointer width or use older compilers; AFAIK, it is not necessary for spin-rs' use case, and disabling it may improve compile times slightly.
- It is only cfg 'portable_atomic_**unsafe**_assume_single_core' is unsafe. It is safe to enable the portable_atomic feature itself.