### PR TITLE
once: merge two tests to prevent flaky test failures

### DIFF
--- a/src/once.rs
+++ b/src/once.rs
@@ -655,8 +655,11 @@ mod tests {
         }
     }
 
+    // This is sort of two test cases, but if we write them as separate test methods
+    // they can be executed concurrently and then fail some small fraction of the
+    // time.
     #[test]
-    fn drop_occurs() {
+    fn drop_occurs_and_skip_uninit_drop() {
         unsafe {
             CALLED = false;
         }
@@ -669,10 +672,7 @@ mod tests {
         assert!(unsafe {
             CALLED
         });
-    }
-
-    #[test]
-    fn skip_uninit_drop() {
+        // Now test that we skip drops for the uninitialized case.
         unsafe {
             CALLED = false;
         }


### PR DESCRIPTION
Without this change, one of these two test methods fails about .75% of
the time (3 times in 500 runs). With this change, all tests pass in
5000 out of 5000 runs, so flaky failures should be a thing of the
past. I tried to reason a way to use a mutex or something here to
avoid fusing the methods, but I couldn't reason out a way to make it
work gracefully so I took the easy way out.