### PR TITLE
Add pinned variants of methods

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,9 @@ std = []
 # This cfg is unsafe and enabling it for multicore systems is unsound.
 portable_atomic = ["portable-atomic"]
 
+[dev-dependencies]
+waker-fn = "1.1.0"
+
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]

--- a/src/mutex.rs
+++ b/src/mutex.rs
@@ -30,6 +30,7 @@ pub use self::ticket::{TicketMutex, TicketMutexGuard};
 use core::{
     fmt,
     ops::{Deref, DerefMut},
+    pin::Pin,
 };
 use crate::{RelaxStrategy, Spin};
 
@@ -170,6 +171,41 @@ impl<T: ?Sized, R: RelaxStrategy> Mutex<T, R> {
             inner: self.inner.lock(),
         }
     }
+
+    /// Locks a pinned [`Mutex`] and returns a pinned version of the mutex guard.
+    /// 
+    /// This is useful for when the data is pinned in memory, such as when it is stored in a
+    /// future.
+    /// 
+    /// ```
+    /// use std::{future::{Future, ready}, task::{Context, Poll}};
+    /// # use std::task::Waker;
+    /// 
+    /// // Create a future and protect it with a spin mutex.
+    /// let my_future = ready(1);
+    /// let lock = spin::Mutex::<_>::new(my_future);
+    /// let lock = Box::pin(lock);
+    /// 
+    /// // Poll the future.
+    /// let waker = noop_waker();
+    /// let mut cx = Context::from_waker(&waker);
+    /// let mut result = lock.as_ref().lock_pinned();
+    /// assert_eq!(result.as_mut().poll(&mut cx), Poll::Ready(1));
+    /// # 
+    /// # fn noop_waker() -> Waker {
+    /// #     waker_fn::waker_fn(|| {})
+    /// # }
+    /// ```
+    #[inline(always)]
+    pub fn lock_pinned(self: Pin<&Self>) -> Pin<MutexGuard<T>> {
+        let guard = self.get_ref().lock();
+
+        // SAFETY: The inner value is guaranteed to be pinned because the mutex is pinned.
+        // We never move ourselves out of the guard.
+        unsafe { 
+            Pin::new_unchecked(guard)
+        }
+    }
 }
 
 impl<T: ?Sized, R> Mutex<T, R> {
@@ -215,6 +251,41 @@ impl<T: ?Sized, R> Mutex<T, R> {
         self.inner
             .try_lock()
             .map(|guard| MutexGuard { inner: guard })
+    }
+
+    /// Tries to lock a pinned [`Mutex`] and returns a pinned version of the mutex guard.
+    /// 
+    /// This is useful for when the data is pinned in memory, such as when it is stored in a
+    /// future.
+    /// 
+    /// ```
+    /// use std::{future::{Future, ready}, task::{Context, Poll}};
+    /// # use std::task::Waker;
+    /// 
+    /// // Create a future and protect it with a spin mutex.
+    /// let my_future = ready(1);
+    /// let lock = spin::Mutex::<_>::new(my_future);
+    /// let lock = Box::pin(lock);
+    /// 
+    /// // Poll the future.
+    /// let waker = noop_waker();
+    /// let mut cx = Context::from_waker(&waker);
+    /// let mut result = lock.as_ref().try_lock_pinned().unwrap();
+    /// assert_eq!(result.as_mut().poll(&mut cx), Poll::Ready(1));
+    /// # 
+    /// # fn noop_waker() -> Waker {
+    /// #     waker_fn::waker_fn(|| {})
+    /// # }
+    /// ```
+    #[inline(always)]
+    pub fn try_lock_pinned(self: Pin<&Self>) -> Option<Pin<MutexGuard<T>>> {
+        let guard = self.get_ref().try_lock();
+
+        // SAFETY: The inner value is guaranteed to be pinned because the mutex is pinned.
+        // We never move ourselves out of the guard.
+        unsafe { 
+            guard.map(|guard| Pin::new_unchecked(guard))
+        }
     }
 
     /// Returns a mutable reference to the underlying data.


### PR DESCRIPTION
I've wanted to use this crate in futures programming; however, there's no real way to go from a `Pin<&Mutex<T>>` to a `Pin<MutexGuard<T>>`. This requires me to use unsafe code when implemented shared futures, e.g:

```rust
#[pin_project]
struct Shared<F>(Arc<Mutex<F>>);

impl<F: Future> Future for Shared<F> {
    type Output = Option<F::Output>;

    fn poll(self: Pin<&mut Self>, ...) {
        let project = self.project();

        // What I want to do:
        match project.0.try_lock_pinned() { /* ... */ }

        // What I am currently doing:
        let mtx = unsafe { Pin::into_inner_unchecked(project.0) };
        let lock = mtx.try_lock().map(|lock| unsafe { Pin::new_unchecked(lock) });
        match lock { /* ... */ }
    }
}
```

This PR aims to make this code possible by adding methods that allow for locking a pinned `Mutex<T>` and `RwLock<T>`. I'm not attached to the names of the methods.