### PR TITLE
Add more tests to the CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,13 +10,36 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
-
+  test:
     runs-on: ubuntu-latest
+    strategy:
+      fast-fail: false
+      matrix:
+        rust: [stable, beta, nightly]
 
     steps:
     - uses: actions/checkout@v2
-    - name: Build
-      run: cargo build --verbose
-    - name: Run tests
+    - name: Install Rust
+      run: rustup update ${{ matrix.rust }} && rustup default ${{ matrix.rust }}
+    - name: Run Tests
       run: cargo test --verbose
+    - run: cargo build --all --all-features --all-targets
+    - name: Catch missing feature flags
+      if: startsWith(matrix.rust, 'nightly')
+      run: cargo check -Z features=dev_dep
+    - name: Install cargo-hack
+      uses: taiki-e/install-action@cargo-hack
+    - run: rustup target add thumbv7m-none-eabi
+    - name: Ensure we don't depend on libstd
+      run: cargo hack build --target thumbv7m-none-eabi --no-dev-deps --no-default-features
+
+    miri:
+      runs-on: ubuntu-latest
+      steps:
+      - uses: actions/checkout@v2
+      - name: Install Rust
+        run: rustup update nightly --component miri && rustup default nightly
+      - run: cargo miri test
+        env:
+          MIRIFLAGS: -Zmiri-strict-provenance -Zmiri-symbolic-alignment-check -Zmiri-disable-isolation
+          RUSTFLAGS: ${{ env.RUSTFLAGS }} -Z randomize-layout


### PR DESCRIPTION
This PR adds some more tests to the CI, including:

- Tests to make sure it runs on `no_std` environments.
- Build with all features enabled and disabled.
- Run MIRI to make sure no unsound behavior is occurring.