### PR TITLE
Add an MSRV policy

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,6 +32,17 @@ jobs:
     - run: rustup target add thumbv7m-none-eabi
     - name: Ensure we don't depend on libstd
       run: cargo hack build --target thumbv7m-none-eabi --no-dev-deps --no-default-features
+  
+  msrv:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version: [1.38.0]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install Rust
+      run: rustup update ${{ matrix.version }} && rustup default ${{ matrix.version }}
+    - run: cargo build --all --all-features --all-targets
 
   miri:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ license = "MIT"
 repository = "https://github.com/mvdnes/spin-rs.git"
 keywords = ["spinlock", "mutex", "rwlock"]
 description = "Spin-based synchronization primitives"
+rust-version = "1.38"
 
 [dependencies]
 lock_api_crate = { package = "lock_api", version = "0.4", optional = true }

--- a/README.md
+++ b/README.md
@@ -127,6 +127,11 @@ time for your crate's users. You can do this like so:
 spin = { version = "x.y", default-features = false, features = [...] }
 ```
 
+## Minimum Safe Rust Version (MSRV)
+
+This crate is guaranteed to compile on a Minimum Safe Rust Version (MSRV) of 1.38.0 and above.
+This version will not be changed without a minor version bump.
+
 ## License
 
 `spin` is distributed under the MIT License, (See `LICENSE`).

--- a/src/relax.rs
+++ b/src/relax.rs
@@ -23,7 +23,10 @@ pub struct Spin;
 impl RelaxStrategy for Spin {
     #[inline(always)]
     fn relax() {
-        core::hint::spin_loop();
+        // Use the deprecated spin_loop_hint() to ensure that we don't get
+        // a higher MSRV than we need to.
+        #[allow(deprecated)]
+        core::sync::atomic::spin_loop_hint();
     }
 }
 

--- a/src/rwlock.rs
+++ b/src/rwlock.rs
@@ -251,7 +251,7 @@ impl<T: ?Sized, R> RwLock<T, R> {
     // Acquire a read lock, returning the new lock value.
     fn acquire_reader(&self) -> usize {
         // An arbitrary cap that allows us to catch overflows long before they happen
-        const MAX_READERS: usize = usize::MAX / READER / 2;
+        const MAX_READERS: usize = core::usize::MAX / READER / 2;
 
         let value = self.lock.fetch_add(READER, Ordering::Acquire);
 


### PR DESCRIPTION
As far as I know, there is no official Minimum Safe Rust Version (MSRV) policy for this crate, which makes it difficult to include it in crates that do have an MSRV policy. After some testing and adjustment, I've found that the MSRV for this crate is **1.38.0**. If you disable some features, it's probably lower, but I think a two-year old version of Rustc is conservative enough. This pull request adds an MSRV policy, as well as a test in the CI to make sure that the crate builds on the MSRV.