### PR TITLE
Update portable-atomic to 1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = "1.38"
 
 [dependencies]
 lock_api_crate = { package = "lock_api", version = "0.4", optional = true }
-portable-atomic = { version = "0.3", optional = true, default-features = false }
+portable-atomic = { version = "1", optional = true, default-features = false }
 
 [features]
 default = ["lock_api", "mutex", "spin_mutex", "rwlock", "once", "lazy", "barrier"]
@@ -52,9 +52,14 @@ lock_api = ["lock_api_crate"]
 # Enables std-only features such as yield-relaxing.
 std = []
 
-# Use the portable_atomic crate to support platforms without native atomic operations
-# cfg 'portable_atomic_unsafe_assume_single_core' must also be set by the final binary crate.
-# This cfg is unsafe and enabling it for multicore systems is unsound.
+# Use the portable_atomic crate to support platforms without native atomic operations.
+# The `portable_atomic_unsafe_assume_single_core` cfg or `critical-section` feature
+# of `portable-atomic` crate must also be set by the final binary crate.
+# When using the cfg, note that it is unsafe and enabling it for multicore systems is unsound.
+# When using the `critical-section` feature, you need to implement the critical-section
+# implementation that sound for your system by implementing an unsafe trait.
+# See the documentation for the `portable-atomic` crate for more information:
+# https://docs.rs/portable-atomic/latest/portable_atomic/#optional-cfg
 portable_atomic = ["portable-atomic"]
 
 [package.metadata.docs.rs]

--- a/README.md
+++ b/README.md
@@ -94,14 +94,20 @@ The crate comes with a few feature flags that you may wish to use.
 
 - `portable_atomic` enables usage of the `portable-atomic` crate
   to support platforms without native atomic operations (Cortex-M0, etc.).
-  The `portable_atomic_unsafe_assume_single_core` cfg flag
-  must also be set by the final binary crate.
-  This can be done by adapting the following snippet to the `.cargo/config` file:
+  The `portable_atomic_unsafe_assume_single_core` cfg or `critical-section` feature
+  of `portable-atomic` crate must also be set by the final binary crate.
+
+  When using the cfg, this can be done by adapting the following snippet to the `.cargo/config` file:
   ```
   [target.<target>]
   rustflags = [ "--cfg", "portable_atomic_unsafe_assume_single_core" ]
   ```
   Note that this cfg is unsafe by nature, and enabling it for multicore systems is unsound.
+
+  When using the `critical-section` feature, you need to implement the critical-section
+  implementation that sound for your system by implementing an unsafe trait.
+  See [the documentation for the `portable-atomic` crate](https://docs.rs/portable-atomic/latest/portable_atomic/#optional-cfg)
+  for more information.
 
 ## Remarks
 


### PR DESCRIPTION
The main change in this release is adding an optional `critical-section` feature[^1] to support custom critical section implementations with [rust-embedded's critical-section](https://github.com/rust-embedded/critical-section) crate. (https://github.com/taiki-e/portable-atomic/pull/51) This allows `portable-atomic` to provide atomic CAS on multicore systems that do not have native atomic CAS instructions.

`portable-atomic` is not used in `spin`'s public API and the (cfg) interfaces of `portable-atomic` 0.3 and `portable-atomic` 1.x are compatible, so this update should not be a breaking change. (https://github.com/taiki-e/portable-atomic/issues/61#issue-1530014746)

[^1]: This is a feature, not a cfg; `critical-section` 1.x doesn't provide the default or opt-in potentially unsound implementation (unlike `critical-section` 0.x where the implementation for single-core was enabled by default), and users must implement the `critical-section` implementation that sound for their system by implementing an unsafe trait (or to use the crate that provides such an implementation). So, we have determined that it is okay to treat this as a safe feature.