### PR TITLE
Bring back the `Send` and `Sync` implementations for `RwLock{Read,Write,Upgradable}Guard`

### DIFF
--- a/src/rwlock.rs
+++ b/src/rwlock.rs
@@ -111,6 +111,15 @@ pub struct RwLockUpgradableGuard<'a, T: 'a + ?Sized, R = Spin> {
 unsafe impl<T: ?Sized + Send, R> Send for RwLock<T, R> {}
 unsafe impl<T: ?Sized + Send + Sync, R> Sync for RwLock<T, R> {}
 
+unsafe impl<T: ?Sized + Send + Sync, R> Send for RwLockWriteGuard<'_, T, R> {}
+unsafe impl<T: ?Sized + Send + Sync, R> Sync for RwLockWriteGuard<'_, T, R> {}
+
+unsafe impl<T: ?Sized + Sync> Send for RwLockReadGuard<'_, T> {}
+unsafe impl<T: ?Sized + Sync> Sync for RwLockReadGuard<'_, T> {}
+
+unsafe impl<T: ?Sized + Send + Sync, R> Send for RwLockUpgradableGuard<'_, T, R> {}
+unsafe impl<T: ?Sized + Send + Sync, R> Sync for RwLockUpgradableGuard<'_, T, R> {}
+
 impl<T, R> RwLock<T, R> {
     /// Creates a new spinlock wrapping the supplied data.
     ///


### PR DESCRIPTION
This PR restores the following auto trait implementations that have been unintentionally(?) removed in #136.

- [`RwLockWriteGuard<'_, T, R>: Send`](https://docs.rs/spin/0.9.4/spin/rwlock/struct.RwLockWriteGuard.html#impl-Send-for-RwLockWriteGuard%3C%27a%2C%20T%2C%20R%3E) if `T: Send + Sync`
- [`RwLockWriteGuard<'_, T, R>: Sync`](https://docs.rs/spin/0.9.4/spin/rwlock/struct.RwLockWriteGuard.html#impl-Sync-for-RwLockWriteGuard%3C%27a%2C%20T%2C%20R%3E) if `T: Send + Sync`
- [`RwLockReadGuard<'_, T>: Send`](https://docs.rs/spin/0.9.4/spin/rwlock/struct.RwLockReadGuard.html#impl-Send-for-RwLockReadGuard%3C%27a%2C%20T%3E) if `T: Sync`
- [`RwLockReadGuard<'_, T>: Sync`](https://docs.rs/spin/0.9.4/spin/rwlock/struct.RwLockReadGuard.html#impl-Sync-for-RwLockReadGuard%3C%27a%2C%20T%3E) if `T: Sync`
- [`RwLockUpgradableGuard<'_, T, R>: Send`](https://docs.rs/spin/0.9.4/spin/rwlock/struct.RwLockUpgradableGuard.html#impl-Send-for-RwLockUpgradableGuard%3C%27a%2C%20T%2C%20R%3E) if `T: Send + Sync`
- [`RwLockUpgradableGuard<'_, T, R>: Sync`](https://docs.rs/spin/0.9.4/spin/rwlock/struct.RwLockUpgradableGuard.html#impl-Sync-for-RwLockUpgradableGuard%3C%27a%2C%20T%2C%20R%3E) if `T: Send + Sync`


