### PR TITLE
Bring back the `Send` and `Sync` implementations for `SpinMutexGuard`

### DIFF
--- a/src/mutex/spin.rs
+++ b/src/mutex/spin.rs
@@ -87,6 +87,9 @@ pub struct SpinMutexGuard<'a, T: ?Sized + 'a> {
 unsafe impl<T: ?Sized + Send, R> Sync for SpinMutex<T, R> {}
 unsafe impl<T: ?Sized + Send, R> Send for SpinMutex<T, R> {}
 
+unsafe impl<T: ?Sized + Sync> Sync for SpinMutexGuard<'_, T> {}
+unsafe impl<T: ?Sized + Send> Send for SpinMutexGuard<'_, T> {}
+
 impl<T, R> SpinMutex<T, R> {
     /// Creates a new [`SpinMutex`] wrapping the supplied data.
     ///


### PR DESCRIPTION
This PR restores the following auto trait implementations that have been unintentionally removed in #125.

- [`SpinMutexGuard<'_, T>: Send`](https://docs.rs/spin/0.9.4/spin/mutex/spin/struct.SpinMutexGuard.html#impl-Send-for-SpinMutexGuard%3C%27a%2C%20T%3E) if `T: Send`
- [`SpinMutexGuard<'_, T>: Sync`](https://docs.rs/spin/0.9.4/spin/mutex/spin/struct.SpinMutexGuard.html#impl-Sync-for-SpinMutexGuard%3C%27a%2C%20T%3E) if `T: Sync`
- [`MutexGuard<'_, T>: Send`](https://docs.rs/spin/0.9.4/spin/mutex/struct.MutexGuard.html#impl-Send-for-MutexGuard%3C%27a%2C%20T%3E) if `T: Send` and `!cfg!(feature = "use_ticket_mutex")`
- [`MutexGuard<'_, T>: Sync`](https://docs.rs/spin/0.9.4/spin/mutex/struct.MutexGuard.html#impl-Sync-for-MutexGuard%3C%27a%2C%20T%3E) if `T: Sync` and `!cfg!(feature = "use_ticket_mutex")`
