### PR TITLE
Implement `Send` and `Sync` for `FairMutexGuard`

### DIFF
--- a/src/mutex/fair.rs
+++ b/src/mutex/fair.rs
@@ -107,6 +107,9 @@ pub enum LockRejectReason {
 unsafe impl<T: ?Sized + Send, R> Sync for FairMutex<T, R> {}
 unsafe impl<T: ?Sized + Send, R> Send for FairMutex<T, R> {}
 
+unsafe impl<T: ?Sized + Sync> Sync for FairMutexGuard<'_, T> {}
+unsafe impl<T: ?Sized + Send> Send for FairMutexGuard<'_, T> {}
+
 impl<T, R> FairMutex<T, R> {
     /// Creates a new [`FairMutex`] wrapping the supplied data.
     ///


### PR DESCRIPTION
This PR adds the following auto trait implementations so that it's in line with other `MutexGuard` types.

- `FairMutexGuard<'_, T>: Send` if `T: Send`
- `FairMutexGuard<'_, T>: Sync` if `T: Sync`