### PR TITLE
Expose weak versions of CAS methods

### DIFF
--- a/src/mutex/spin.rs
+++ b/src/mutex/spin.rs
@@ -179,7 +179,7 @@ impl<T: ?Sized, R: RelaxStrategy> SpinMutex<T, R> {
         // when called in a loop.
         loop {
             if let Some(guard) = self.try_lock_weak() {
-                return guard;
+                break guard;
             }
 
             while self.is_locked() {

--- a/src/mutex/spin.rs
+++ b/src/mutex/spin.rs
@@ -177,20 +177,14 @@ impl<T: ?Sized, R: RelaxStrategy> SpinMutex<T, R> {
     pub fn lock(&self) -> SpinMutexGuard<T> {
         // Can fail to lock even if the spinlock is not locked. May be more efficient than `try_lock`
         // when called in a loop.
-        while self
-            .lock
-            .compare_exchange_weak(false, true, Ordering::Acquire, Ordering::Relaxed)
-            .is_err()
-        {
-            // Wait until the lock looks unlocked before retrying
+        loop {
+            if let Some(guard) = self.try_lock_weak() {
+                return guard;
+            }
+
             while self.is_locked() {
                 R::relax();
             }
-        }
-
-        SpinMutexGuard {
-            lock: &self.lock,
-            data: unsafe { &mut *self.data.get() },
         }
     }
 }
@@ -237,10 +231,34 @@ impl<T: ?Sized, R> SpinMutex<T, R> {
     pub fn try_lock(&self) -> Option<SpinMutexGuard<T>> {
         // The reason for using a strong compare_exchange is explained here:
         // https://github.com/Amanieu/parking_lot/pull/207#issuecomment-575869107
-        if self
-            .lock
-            .compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed)
-            .is_ok()
+        self.try_lock_internal(true)
+    }
+
+    /// Try to lock this [`SpinMutex`], returning a lock guard if succesful.
+    ///
+    /// Unlike [`SpinMutex::try_lock`], this function is allowed to spuriously fail even when the mutex is unlocked,
+    /// which can result in more efficient code on some platforms.
+    #[inline(always)]
+    pub fn try_lock_weak(&self) -> Option<SpinMutexGuard<T>> {
+        self.try_lock_internal(false)
+    }
+
+    #[inline(always)]
+    fn try_lock_internal(&self, strong: bool) -> Option<SpinMutexGuard<T>> {
+        let f = if strong {
+            AtomicBool::compare_exchange
+        } else {
+            AtomicBool::compare_exchange_weak
+        };
+
+        if f(
+            &self.lock,
+            false,
+            true,
+            Ordering::Acquire,
+            Ordering::Relaxed,
+        )
+        .is_ok()
         {
             Some(SpinMutexGuard {
                 lock: &self.lock,

--- a/src/rwlock.rs
+++ b/src/rwlock.rs
@@ -409,6 +409,15 @@ impl<T: ?Sized, R> RwLock<T, R> {
         self.try_write_internal(true)
     }
 
+    /// Attempt to lock this rwlock with exclusive write access.
+    ///
+    /// Unlike [`RwLock::try_write`], this function is allowed to spuriously fail even when acquiring exclusive write access
+    /// would otherwise succeed, which can result in more efficient code on some platforms.
+    #[inline]
+    pub fn try_write_weak(&self) -> Option<RwLockWriteGuard<T, R>> {
+        self.try_write_internal(false)
+    }
+
     /// Tries to obtain an upgradeable lock guard.
     #[inline]
     pub fn try_upgradeable_read(&self) -> Option<RwLockUpgradableGuard<T, R>> {
@@ -564,6 +573,15 @@ impl<'rwlock, T: ?Sized, R> RwLockUpgradableGuard<'rwlock, T, R> {
     #[inline]
     pub fn try_upgrade(self) -> Result<RwLockWriteGuard<'rwlock, T, R>, Self> {
         self.try_upgrade_internal(true)
+    }
+
+    /// Tries to upgrade an upgradeable lock guard to a writable lock guard.
+    ///
+    /// Unlike [`RwLockUpgradableGuard::try_upgrade`], this function is allowed to spuriously fail even when upgrading
+    /// would otherwise succeed, which can result in more efficient code on some platforms.
+    #[inline]
+    pub fn try_upgrade_weak(self) -> Result<RwLockWriteGuard<'rwlock, T, R>, Self> {
+        self.try_upgrade_internal(false)
     }
 
     #[inline]


### PR DESCRIPTION
Hi,

I'm working on implementing sync primitives in [Theseus OS](https://github.com/theseus-os/Theseus) on top of spin locks. We currently [have to implement our own spin lock](https://github.com/theseus-os/Theseus/blob/cb77432051dde0caf7fcf7eb4c04fa231916f624/libs/sync/src/mutex.rs#L146-L281) that is identical to `spin` except that it exposes `try_lock_weak`, so that we can have custom `lock` implementations that use a weak CMPXCHG, while still using a strong CMPXCHG for `try_lock`.

It would be nice if we could upstream this so that we could directly depend on `spin`. I think it makes sense to include it as `spin` is often used to build higher-level primitives which could use a weak CMPXCHG for better performance.