### PR TITLE
Enable portable-atomic's require-cas feature

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,9 +24,9 @@ jobs:
     - name: Install Rust
       run: rustup update ${{ matrix.rust }} && rustup default ${{ matrix.rust }}
     - name: Run Tests
-      run: cargo test --features _test_atomic --verbose
+      run: cargo test --verbose
     - name: Build crate
-      run: cargo build --all --features _test_atomic --all-targets
+      run: cargo build --all --all-features --all-targets
     - name: Catch missing feature flags
       if: startsWith(matrix.rust, 'nightly')
       run: cargo check -Z features=dev_dep
@@ -46,7 +46,7 @@ jobs:
     - name: Install Rust
       run: rustup update ${{ matrix.version }} && rustup default ${{ matrix.version }}
     - name: Check MSRV
-      run: cargo check --all --features _test_atomic
+      run: cargo check --all --all-features
 
   miri:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,8 @@ rust-version = "1.38"
 
 [dependencies]
 lock_api_crate = { package = "lock_api", version = "0.4", optional = true }
-portable-atomic = { version = "1", optional = true, default-features = false }
+# Enable require-cas feature to provide a better error message if the end user forgets to use the cfg or feature.
+portable-atomic = { version = "1.3", optional = true, default-features = false, features = ["require-cas"] }
 
 [features]
 default = ["lock_api", "mutex", "spin_mutex", "rwlock", "once", "lazy", "barrier"]
@@ -51,11 +52,6 @@ lock_api = ["lock_api_crate"]
 
 # Enables std-only features such as yield-relaxing.
 std = []
-
-# An alias of all features *except* `portable_atomic`. Used only for internal crate tests.
-# Do not use this feature, its removal is not considered a breaking change and its behaviour may change.
-# If you're working on `spin` and you're adding a feature, please add it to this list.
-_test_atomic = ["mutex", "spin_mutex", "ticket_mutex", "fair_mutex", "rwlock", "once", "lazy", "barrier", "lock_api", "std"]
 
 # Use the portable_atomic crate to support platforms without native atomic operations.
 # The `portable_atomic_unsafe_assume_single_core` cfg or `critical-section` feature

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,82 +68,34 @@ extern crate portable_atomic;
 
 #[cfg(not(feature = "portable_atomic"))]
 use core::sync::atomic;
-#[cfg(all(feature = "portable_atomic", portable_atomic_unsafe_assume_single_core))]
+#[cfg(feature = "portable_atomic")]
 use portable_atomic as atomic;
 
-#[cfg(all(
-    feature = "portable_atomic",
-    not(portable_atomic_unsafe_assume_single_core)
-))]
-core::compile_error!("The feature \"portable_atomic\" requires the \"portable_atomic_unsafe_assume_single_core\" cfg flag to be enabled. See https://docs.rs/portable-atomic/latest/portable_atomic/#optional-cfg.");
-
-#[cfg(all(
-    feature = "barrier",
-    any(
-        not(feature = "portable_atomic"),
-        all(feature = "portable_atomic", portable_atomic_unsafe_assume_single_core)
-    )
-))]
+#[cfg(feature = "barrier")]
 #[cfg_attr(docsrs, doc(cfg(feature = "barrier")))]
 pub mod barrier;
-#[cfg(all(
-    feature = "lazy",
-    any(
-        not(feature = "portable_atomic"),
-        all(feature = "portable_atomic", portable_atomic_unsafe_assume_single_core)
-    )
-))]
+#[cfg(feature = "lazy")]
 #[cfg_attr(docsrs, doc(cfg(feature = "lazy")))]
 pub mod lazy;
-#[cfg(all(
-    feature = "mutex",
-    any(
-        not(feature = "portable_atomic"),
-        all(feature = "portable_atomic", portable_atomic_unsafe_assume_single_core)
-    )
-))]
+#[cfg(feature = "mutex")]
 #[cfg_attr(docsrs, doc(cfg(feature = "mutex")))]
 pub mod mutex;
-#[cfg(all(
-    feature = "once",
-    any(
-        not(feature = "portable_atomic"),
-        all(feature = "portable_atomic", portable_atomic_unsafe_assume_single_core)
-    )
-))]
+#[cfg(feature = "once")]
 #[cfg_attr(docsrs, doc(cfg(feature = "once")))]
 pub mod once;
 pub mod relax;
-#[cfg(all(
-    feature = "rwlock",
-    any(
-        not(feature = "portable_atomic"),
-        all(feature = "portable_atomic", portable_atomic_unsafe_assume_single_core)
-    )
-))]
+#[cfg(feature = "rwlock")]
 #[cfg_attr(docsrs, doc(cfg(feature = "rwlock")))]
 pub mod rwlock;
 
-#[cfg(all(
-    feature = "mutex",
-    any(
-        not(feature = "portable_atomic"),
-        all(feature = "portable_atomic", portable_atomic_unsafe_assume_single_core)
-    )
-))]
+#[cfg(feature = "mutex")]
 #[cfg_attr(docsrs, doc(cfg(feature = "mutex")))]
 pub use mutex::MutexGuard;
 #[cfg(feature = "std")]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub use relax::Yield;
 pub use relax::{RelaxStrategy, Spin};
-#[cfg(all(
-    feature = "rwlock",
-    any(
-        not(feature = "portable_atomic"),
-        all(feature = "portable_atomic", portable_atomic_unsafe_assume_single_core)
-    )
-))]
+#[cfg(feature = "rwlock")]
 #[cfg_attr(docsrs, doc(cfg(feature = "rwlock")))]
 pub use rwlock::RwLockReadGuard;
 
@@ -155,13 +107,7 @@ pub use rwlock::RwLockReadGuard;
 ///
 /// A note for advanced users: this alias exists to avoid subtle type inference errors due to the default relax
 /// strategy type parameter. If you need a non-default relax strategy, use the fully-qualified path.
-#[cfg(all(
-    feature = "barrier",
-    any(
-        not(feature = "portable_atomic"),
-        all(feature = "portable_atomic", portable_atomic_unsafe_assume_single_core)
-    )
-))]
+#[cfg(feature = "barrier")]
 #[cfg_attr(docsrs, doc(cfg(feature = "barrier")))]
 pub type Barrier = crate::barrier::Barrier;
 
@@ -169,13 +115,7 @@ pub type Barrier = crate::barrier::Barrier;
 ///
 /// A note for advanced users: this alias exists to avoid subtle type inference errors due to the default relax
 /// strategy type parameter. If you need a non-default relax strategy, use the fully-qualified path.
-#[cfg(all(
-    feature = "lazy",
-    any(
-        not(feature = "portable_atomic"),
-        all(feature = "portable_atomic", portable_atomic_unsafe_assume_single_core)
-    )
-))]
+#[cfg(feature = "lazy")]
 #[cfg_attr(docsrs, doc(cfg(feature = "lazy")))]
 pub type Lazy<T, F = fn() -> T> = crate::lazy::Lazy<T, F>;
 
@@ -183,13 +123,7 @@ pub type Lazy<T, F = fn() -> T> = crate::lazy::Lazy<T, F>;
 ///
 /// A note for advanced users: this alias exists to avoid subtle type inference errors due to the default relax
 /// strategy type parameter. If you need a non-default relax strategy, use the fully-qualified path.
-#[cfg(all(
-    feature = "mutex",
-    any(
-        not(feature = "portable_atomic"),
-        all(feature = "portable_atomic", portable_atomic_unsafe_assume_single_core)
-    )
-))]
+#[cfg(feature = "mutex")]
 #[cfg_attr(docsrs, doc(cfg(feature = "mutex")))]
 pub type Mutex<T> = crate::mutex::Mutex<T>;
 
@@ -197,13 +131,7 @@ pub type Mutex<T> = crate::mutex::Mutex<T>;
 ///
 /// A note for advanced users: this alias exists to avoid subtle type inference errors due to the default relax
 /// strategy type parameter. If you need a non-default relax strategy, use the fully-qualified path.
-#[cfg(all(
-    feature = "once",
-    any(
-        not(feature = "portable_atomic"),
-        all(feature = "portable_atomic", portable_atomic_unsafe_assume_single_core)
-    )
-))]
+#[cfg(feature = "once")]
 #[cfg_attr(docsrs, doc(cfg(feature = "once")))]
 pub type Once<T = ()> = crate::once::Once<T>;
 
@@ -211,13 +139,7 @@ pub type Once<T = ()> = crate::once::Once<T>;
 ///
 /// A note for advanced users: this alias exists to avoid subtle type inference errors due to the default relax
 /// strategy type parameter. If you need a non-default relax strategy, use the fully-qualified path.
-#[cfg(all(
-    feature = "rwlock",
-    any(
-        not(feature = "portable_atomic"),
-        all(feature = "portable_atomic", portable_atomic_unsafe_assume_single_core)
-    )
-))]
+#[cfg(feature = "rwlock")]
 #[cfg_attr(docsrs, doc(cfg(feature = "rwlock")))]
 pub type RwLock<T> = crate::rwlock::RwLock<T>;
 
@@ -226,13 +148,7 @@ pub type RwLock<T> = crate::rwlock::RwLock<T>;
 ///
 /// A note for advanced users: this alias exists to avoid subtle type inference errors due to the default relax
 /// strategy type parameter. If you need a non-default relax strategy, use the fully-qualified path.
-#[cfg(all(
-    feature = "rwlock",
-    any(
-        not(feature = "portable_atomic"),
-        all(feature = "portable_atomic", portable_atomic_unsafe_assume_single_core)
-    )
-))]
+#[cfg(feature = "rwlock")]
 #[cfg_attr(docsrs, doc(cfg(feature = "rwlock")))]
 pub type RwLockUpgradableGuard<'a, T> = crate::rwlock::RwLockUpgradableGuard<'a, T>;
 
@@ -240,13 +156,7 @@ pub type RwLockUpgradableGuard<'a, T> = crate::rwlock::RwLockUpgradableGuard<'a,
 ///
 /// A note for advanced users: this alias exists to avoid subtle type inference errors due to the default relax
 /// strategy type parameter. If you need a non-default relax strategy, use the fully-qualified path.
-#[cfg(all(
-    feature = "rwlock",
-    any(
-        not(feature = "portable_atomic"),
-        all(feature = "portable_atomic", portable_atomic_unsafe_assume_single_core)
-    )
-))]
+#[cfg(feature = "rwlock")]
 #[cfg_attr(docsrs, doc(cfg(feature = "rwlock")))]
 pub type RwLockWriteGuard<'a, T> = crate::rwlock::RwLockWriteGuard<'a, T>;
 


### PR DESCRIPTION
This provides a better error message if the end user forgets to use the cfg or feature. (Also allows using the critical-section feature instead of the cfg.)

```console
$ cargo build --target thumbv6m-none-eabi --no-default-features --features spin_mutex,portable_atomic
   Compiling portable-atomic v1.3.2
error: dependents require atomic CAS but not available on this target by default;
       consider using portable_atomic_unsafe_assume_single_core cfg or critical-section feature.
       see <https://docs.rs/portable-atomic/latest/portable_atomic/#optional-cfg> for more.
```

This also reverts the following commits (partially):
- https://github.com/mvdnes/spin-rs/commit/94cd9c54d717e9db854dc00e5683d9749b1d8cb2
- https://github.com/mvdnes/spin-rs/commit/b1ee8150f292be95fec166b141029d1e6af983f2
- https://github.com/mvdnes/spin-rs/commit/0e0ddcaf7ba0d073a4f1b8700421dc29658c53d4
- https://github.com/mvdnes/spin-rs/commit/3d061b84e0f63e060cfd719bceb3c70d3d52cac3