### PR TITLE
Fix Debug formatting

### DIFF
--- a/src/mutex/spin.rs
+++ b/src/mutex/spin.rs
@@ -291,7 +291,7 @@ impl<T: ?Sized + fmt::Debug, R> fmt::Debug for SpinMutex<T, R> {
         match self.try_lock() {
             Some(guard) => write!(f, "Mutex {{ data: ")
                 .and_then(|()| (&*guard).fmt(f))
-                .and_then(|()| write!(f, "}}")),
+                .and_then(|()| write!(f, " }}")),
             None => write!(f, "Mutex {{ <locked> }}"),
         }
     }

--- a/src/mutex/ticket.rs
+++ b/src/mutex/ticket.rs
@@ -159,7 +159,7 @@ impl<T: ?Sized + fmt::Debug, R> fmt::Debug for TicketMutex<T, R> {
         match self.try_lock() {
             Some(guard) => write!(f, "Mutex {{ data: ")
                 .and_then(|()| (&*guard).fmt(f))
-                .and_then(|()| write!(f, "}}")),
+                .and_then(|()| write!(f, " }}")),
             None => write!(f, "Mutex {{ <locked> }}"),
         }
     }

--- a/src/rwlock.rs
+++ b/src/rwlock.rs
@@ -458,7 +458,7 @@ impl<T: ?Sized + fmt::Debug, R> fmt::Debug for RwLock<T, R> {
         match self.try_read() {
             Some(guard) => write!(f, "RwLock {{ data: ")
                 .and_then(|()| (&*guard).fmt(f))
-                .and_then(|()| write!(f, "}}")),
+                .and_then(|()| write!(f, " }}")),
             None => write!(f, "RwLock {{ <locked> }}"),
         }
     }


### PR DESCRIPTION
Adds a missing space in the Debug implementations for RwLock and spin and ticket mutexes