### PR TITLE
Fix lock_api feature name for RawRwLockUpgradeDowngrade

### DIFF
--- a/src/rwlock.rs
+++ b/src/rwlock.rs
@@ -931,8 +931,8 @@ unsafe impl<R: RelaxStrategy> lock_api_crate::RawRwLockDowngrade for RwLock<(), 
     }
 }
 
-#[cfg(feature = "lock_api1")]
-unsafe impl lock_api::RawRwLockUpgradeDowngrade for RwLock<()> {
+#[cfg(feature = "lock_api")]
+unsafe impl<R: RelaxStrategy> lock_api_crate::RawRwLockUpgradeDowngrade for RwLock<(), R> {
     unsafe fn downgrade_upgradable(&self) {
         let tmp_guard = RwLockUpgradableGuard {
             inner: self,


### PR DESCRIPTION
Changes:
- Rename old feature name`lock_api1` to new feature name `lock_api` (I guess this has been forgotten?).
- Should import `lock_api_crate` as the package name instead of external `lock_api` crate dependency.
- Associated type of phantom data of RwLock requires that it already implement the RelaxStrategy trait.
