### PR TITLE
more intuitive portable-atomic feature etc.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [1.38.0]
+        version: [1.60.0]
     steps:
     - uses: actions/checkout@v3
     - name: Install Rust

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+### Fixed
+
+# [0.10.0] - (Pending)
+
+### Added
+
+### Changed
+
 - Updated MSRV to 1.60
 - Use `dep:` syntax in Cargo.toml
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- More intuitive `portable-atomic` option
+
 ### Changed
+
+- Updated MSRV to 1.60
+- Use `dep:` syntax in Cargo.toml
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT"
 repository = "https://github.com/mvdnes/spin-rs.git"
 keywords = ["spinlock", "mutex", "rwlock"]
 description = "Spin-based synchronization primitives"
-rust-version = "1.38"
+rust-version = "1.60"
 
 [dependencies]
 lock_api_crate = { package = "lock_api", version = "0.4", optional = true }
@@ -48,19 +48,20 @@ lazy = ["once"]
 barrier = ["mutex"]
 
 # Enables `lock_api`-compatible types that use the primitives in this crate internally.
-lock_api = ["lock_api_crate"]
+lock_api = ["dep:lock_api_crate"]
 
 # Enables std-only features such as yield-relaxing.
 std = []
 
-# Use the portable_atomic crate to support platforms without native atomic operations.
+# Use the `portable-atomic` crate to support platforms without native atomic operations.
 # The `portable_atomic_unsafe_assume_single_core` cfg or `critical-section` feature
 # of `portable-atomic` crate must also be set by the final binary crate.
-# When using the cfg, note that it is unsafe and enabling it for multicore systems is unsound.
-# When using the `critical-section` feature, you need to implement the critical-section
-# implementation that sound for your system by implementing an unsafe trait.
-# See the documentation for the `portable-atomic` crate for more information:
-# https://docs.rs/portable-atomic/latest/portable_atomic/#optional-cfg
+# See the documentation for the `portable-atomic` crate for more information
+# with some requirements for no-std build:
+# https://github.com/taiki-e/portable-atomic#optional-features
+portable-atomic = ["dep:portable-atomic"]
+
+# Deprecated alias:
 portable_atomic = ["portable-atomic"]
 
 [package.metadata.docs.rs]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spin"
-version = "0.9.8"
+version = "0.10.0"
 authors = [
     "Mathijs van de Nes <git@mathijs.vd-nes.nl>",
     "John Ericson <git@JohnEricson.me>",

--- a/README.md
+++ b/README.md
@@ -92,22 +92,13 @@ The crate comes with a few feature flags that you may wish to use.
 
 - `std` enables support for thread yielding instead of spinning.
 
-- `portable_atomic` enables usage of the `portable-atomic` crate
+- `portable-atomic` enables usage of the `portable-atomic` crate
   to support platforms without native atomic operations (Cortex-M0, etc.).
-  The `portable_atomic_unsafe_assume_single_core` cfg or `critical-section` feature
+  The `portable_atomic_unsafe_assume_single_core` or `critical-section` feature
   of `portable-atomic` crate must also be set by the final binary crate.
-
-  When using the cfg, this can be done by adapting the following snippet to the `.cargo/config` file:
-  ```
-  [target.<target>]
-  rustflags = [ "--cfg", "portable_atomic_unsafe_assume_single_core" ]
-  ```
-  Note that this cfg is unsafe by nature, and enabling it for multicore systems is unsound.
-
-  When using the `critical-section` feature, you need to implement the critical-section
-  implementation that sound for your system by implementing an unsafe trait.
-  See [the documentation for the `portable-atomic` crate](https://docs.rs/portable-atomic/latest/portable_atomic/#optional-cfg)
-  for more information.
+  See the documentation for the `portable-atomic` crate for more information
+  with some requirements for no-std build:
+  https://github.com/taiki-e/portable-atomic#optional-features
 
 ## Remarks
 
@@ -135,7 +126,7 @@ spin = { version = "x.y", default-features = false, features = [...] }
 
 ## Minimum Safe Rust Version (MSRV)
 
-This crate is guaranteed to compile on a Minimum Safe Rust Version (MSRV) of 1.38.0 and above.
+This crate is guaranteed to compile on a Minimum Safe Rust Version (MSRV) of 1.60.0 and above.
 This version will not be changed without a minor version bump.
 
 ## License

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,16 +59,23 @@
 //!   starvation
 //!
 //! - `std` enables support for thread yielding instead of spinning
+//!
+//! - `portable-atomic` enables usage of the `portable-atomic` crate
+//!   to support platforms without native atomic operations (Cortex-M0, etc.).
+//!   See the documentation for the `portable-atomic` crate for more information
+//!   with some requirements for no-std build:
+//!   https://github.com/taiki-e/portable-atomic#optional-features
+
 
 #[cfg(any(test, feature = "std"))]
 extern crate core;
 
-#[cfg(feature = "portable_atomic")]
+#[cfg(feature = "portable-atomic")]
 extern crate portable_atomic;
 
-#[cfg(not(feature = "portable_atomic"))]
+#[cfg(not(feature = "portable-atomic"))]
 use core::sync::atomic;
-#[cfg(feature = "portable_atomic")]
+#[cfg(feature = "portable-atomic")]
 use portable_atomic as atomic;
 
 #[cfg(feature = "barrier")]


### PR DESCRIPTION
Fixes #170 - non-breaking feature update - based on & supersedes PR #171

__UPDATED as follows__

- include `dep:` syntax updates from PR #171
- update some documentation to update reference & avoid duplicated info
- increase MSRV to 1.60 in Cargo.toml & in `.github/`
- crate version -> 0.10.0

I have also tried CI in my own fork: https://github.com/brody4hire/spin-rs/pull/1

---

P.S. I was hoping that the implicit feature support would be removed in Rust 2024, which is part of the root cause, but this update is now held up: https://github.com/rust-lang/cargo/issues/12826#issuecomment-2386352960

---

/cc @jamesmunns @Dirbaio