### PR TITLE
Add CI workflow for formatting code.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -66,3 +66,15 @@ jobs:
       env:
         MIRIFLAGS: -Zmiri-strict-provenance -Zmiri-symbolic-alignment-check -Zmiri-disable-isolation -Zmiri-ignore-leaks
         RUSTFLAGS: ${{ env.RUSTFLAGS }} -Z randomize-layout
+
+  formatting:
+    name: cargo fmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # Ensure rustfmt is installed and setup problem matcher
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          components: rustfmt
+      - name: Rustfmt Check
+        uses: actions-rust-lang/rustfmt@v1

--- a/benches/mutex.rs
+++ b/benches/mutex.rs
@@ -13,7 +13,10 @@ trait Mutex<T>: Send + Sync + 'static {
 }
 
 impl<T: Send + 'static> Mutex<T> for spin::mutex::SpinMutex<T> {
-    type Guard<'a> = spin::mutex::SpinMutexGuard<'a, T> where Self: 'a;
+    type Guard<'a>
+        = spin::mutex::SpinMutexGuard<'a, T>
+    where
+        Self: 'a;
     fn new(x: T) -> Self {
         spin::mutex::SpinMutex::new(x)
     }
@@ -23,7 +26,10 @@ impl<T: Send + 'static> Mutex<T> for spin::mutex::SpinMutex<T> {
 }
 
 impl<T: Send + 'static> Mutex<T> for spin::mutex::TicketMutex<T> {
-    type Guard<'a> = spin::mutex::TicketMutexGuard<'a, T> where Self: 'a;
+    type Guard<'a>
+        = spin::mutex::TicketMutexGuard<'a, T>
+    where
+        Self: 'a;
     fn new(x: T) -> Self {
         spin::mutex::TicketMutex::new(x)
     }
@@ -33,7 +39,10 @@ impl<T: Send + 'static> Mutex<T> for spin::mutex::TicketMutex<T> {
 }
 
 impl<T: Send + 'static> Mutex<T> for std::sync::Mutex<T> {
-    type Guard<'a> = std::sync::MutexGuard<'a, T> where Self: 'a;
+    type Guard<'a>
+        = std::sync::MutexGuard<'a, T>
+    where
+        Self: 'a;
     fn new(x: T) -> Self {
         std::sync::Mutex::new(x)
     }


### PR DESCRIPTION
I used the template from https://github.com/actions-rust-lang/rustfmt and added it to the existing workflow. But I am far from beeing an expert on this.
It worked on my fork. I mean, it failed, and then I pushed a change with cargo fmt and it went through afterwards.

Feel free to change or ignore it.