### PR TITLE
Chore: fix cargo clippy warnings

### DIFF
--- a/src/mutex.rs
+++ b/src/mutex.rs
@@ -258,7 +258,7 @@ impl<T: ?Sized + fmt::Debug, R> fmt::Debug for Mutex<T, R> {
     }
 }
 
-impl<T: ?Sized + Default, R> Default for Mutex<T, R> {
+impl<T: Default, R> Default for Mutex<T, R> {
     fn default() -> Self {
         Self::new(Default::default())
     }
@@ -304,13 +304,13 @@ impl<'a, T: ?Sized + fmt::Display> fmt::Display for MutexGuard<'a, T> {
 impl<'a, T: ?Sized> Deref for MutexGuard<'a, T> {
     type Target = T;
     fn deref(&self) -> &T {
-        &*self.inner
+        &self.inner
     }
 }
 
 impl<'a, T: ?Sized> DerefMut for MutexGuard<'a, T> {
     fn deref_mut(&mut self) -> &mut T {
-        &mut *self.inner
+        &mut self.inner
     }
 }
 

--- a/src/mutex/spin.rs
+++ b/src/mutex/spin.rs
@@ -330,14 +330,14 @@ impl<T: ?Sized + fmt::Debug, R> fmt::Debug for SpinMutex<T, R> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self.try_lock() {
             Some(guard) => write!(f, "Mutex {{ data: ")
-                .and_then(|()| (&*guard).fmt(f))
+                .and_then(|()| (*guard).fmt(f))
                 .and_then(|()| write!(f, " }}")),
             None => write!(f, "Mutex {{ <locked> }}"),
         }
     }
 }
 
-impl<T: ?Sized + Default, R> Default for SpinMutex<T, R> {
+impl<T: Default, R> Default for SpinMutex<T, R> {
     fn default() -> Self {
         Self::new(Default::default())
     }

--- a/src/once.rs
+++ b/src/once.rs
@@ -267,10 +267,10 @@ impl<T, R: RelaxStrategy> Once<T, R> {
                 None => BeginInit::Retry,
             },
             Err(Status::Complete) => {
-                return BeginInit::Done(unsafe {
+                BeginInit::Done(unsafe {
                     // SAFETY: The status is Complete
                     self.force_get()
-                });
+                })
             }
             Err(Status::Incomplete) => {
                 // The compare_exchange failed, so this shouldn't ever be reached,

--- a/src/relax.rs
+++ b/src/relax.rs
@@ -23,10 +23,7 @@ pub struct Spin;
 impl RelaxStrategy for Spin {
     #[inline(always)]
     fn relax() {
-        // Use the deprecated spin_loop_hint() to ensure that we don't get
-        // a higher MSRV than we need to.
-        #[allow(deprecated)]
-        core::sync::atomic::spin_loop_hint();
+        core::hint::spin_loop();
     }
 }
 


### PR DESCRIPTION
I ran cargo clippy and got some warnings. Those were removed with the first commit.
After that, I checked if there were any #[allow] sections.  => Therefore I replaced the deprecated spin_loop with the newer upstream solution.