### PR TITLE
once: fix stale TODO with stable `MaybeUninit::assume_init_drop`

### DIFF
--- a/src/once.rs
+++ b/src/once.rs
@@ -583,10 +583,7 @@ impl<T, R> Drop for Once<T, R> {
     fn drop(&mut self) {
         // No need to do any atomic access here, we have &mut!
         if *self.status.get_mut() == Status::Complete {
-            unsafe {
-                //TODO: Use MaybeUninit::assume_init_drop once stabilised
-                core::ptr::drop_in_place((*self.data.get()).as_mut_ptr());
-            }
+            unsafe { self.data.get_mut().assume_init_drop() }
         }
     }
 }


### PR DESCRIPTION
`MaybeUninit::assume_init_drop` has been [stable since Rust 1.60](https://doc.rust-lang.org/core/mem/union.MaybeUninit.html#method.assume_init_drop), so this is comfortably within the crate's current MSRV of Rust 1.71 .