### PR TITLE
Add `rustc-dep-of-std` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,8 @@ edition = "2021"
 lock_api_crate = { package = "lock_api", version = "0.4", optional = true }
 # Enable require-cas feature to provide a better error message if the end user forgets to use the cfg or feature.
 portable-atomic = { version = "1.3", optional = true, default-features = false, features = ["require-cas"] }
+# Allows this crate to be used as a dependency of the Rust standard library
+core = { version = "1.0.0", optional = true, package = "rustc-std-workspace-core" }
 
 [features]
 default = ["lock_api", "mutex", "spin_mutex", "rwlock", "once", "lazylock", "barrier"]
@@ -67,6 +69,8 @@ portable-atomic = ["dep:portable-atomic"]
 
 # Deprecated alias:
 portable_atomic = ["portable-atomic"]
+
+rustc-dep-of-std = ["core"]
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
This feature allows this crate to be used as a dependency of the Rust standard library. My use case is in the implementation of the `x86_64-fortanix-unknown-sgx` target of the standard library. See https://github.com/fortanix/rust-sgx/tree/arash/insecure-time-rustc-dep-of-std. Note that `insecure-time` is a dependency of the standard library for the SGX target.

The pattern of introducing a `rustc-dep-of-std` feature seems to be the standard way of going about it. Here is an example: https://github.com/rust-lang/cfg-if/blob/main/Cargo.toml